### PR TITLE
Implement Automatic Reference Handling for LValues

### DIFF
--- a/include/Parser/AST.hpp
+++ b/include/Parser/AST.hpp
@@ -101,6 +101,7 @@ class Type {
   bool isGeneric = false;
   bool safeType = false;
   Type *typeHint;
+  bool isReference = false;
 
   struct FPointerArgs {
     Type *returnType = nullptr;

--- a/include/Parser/AST.hpp
+++ b/include/Parser/AST.hpp
@@ -102,6 +102,7 @@ class Type {
   bool safeType = false;
   Type *typeHint;
   bool isReference = false;
+  asmc::Size refSize;
 
   struct FPointerArgs {
     Type *returnType = nullptr;

--- a/include/Parser/AST/Statements/Assign.hpp
+++ b/include/Parser/AST/Statements/Assign.hpp
@@ -14,6 +14,7 @@ class Assign : public Statement {
   Expr *expr;
   links::LinkedList<std::string> modList;
   links::LinkedList<Expr *> indices;
+  bool to = false;
   gen::GenerationResult const generate(gen::CodeGenerator &generator) override;
   Assign() = default;
   Assign(const std::string &ident, const links::LinkedList<Expr *> &indices,

--- a/include/Parser/AST/Statements/Function.hpp
+++ b/include/Parser/AST/Statements/Function.hpp
@@ -21,6 +21,7 @@ class Function : public Member, public Statement {
   int req = 0;
   std::vector<Type> argTypes;
   links::LinkedList<Expr *> decoratorArgs;
+  std::vector<bool> mutability;
   bool isLambda = false;
   bool flex = false;
   bool mask;

--- a/include/Parser/Parser.hpp
+++ b/include/Parser/Parser.hpp
@@ -20,7 +20,8 @@ class Parser {
   ast::Expr *parseExpr(links::LinkedList<lex::Token *> &tokens);
   ast::Statement *parseArgs(links::LinkedList<lex::Token *> &tokens,
                             char delimn, char close,
-                            std::vector<ast::Type> &types, int &requiered);
+                            std::vector<ast::Type> &types, int &requiered,
+                            std::vector<bool> &mutability);
   void addType(std::string name, asmc::OpType opType, asmc::Size size);
   void addType(std::string name, asmc::OpType opType, asmc::Size size,
                bool isGeneric);

--- a/src/Parser/AST/Statements/Assign.cpp
+++ b/src/Parser/AST/Statements/Assign.cpp
@@ -143,7 +143,7 @@ gen::GenerationResult const Assign::generate(gen::CodeGenerator &generator) {
     mov->to = output;
   };
 
-  if (!this->reference && !fin->mutable_ && !this->override) {
+  if (!fin->mutable_ && !this->override) {
     generator.alert("cannot this to const " + fin->symbol);
   }
 
@@ -152,7 +152,7 @@ gen::GenerationResult const Assign::generate(gen::CodeGenerator &generator) {
   file.text << mov2;
   file.text << mov;
   file << std::get<3>(resolved);
-  if (this->modList.count == 0 && !this->reference)
+  if (this->modList.count == 0)
     gen::scope::ScopeManager::getInstance()->addAssign(fin->symbol);
 
   if (generator.TypeList[fin->type.typeName] == nullptr) {

--- a/src/Parser/AST/Statements/Assign.cpp
+++ b/src/Parser/AST/Statements/Assign.cpp
@@ -143,8 +143,9 @@ gen::GenerationResult const Assign::generate(gen::CodeGenerator &generator) {
     mov->to = output;
   };
 
-  if (!fin->mutable_ && !this->override) {
-    generator.alert("cannot this to const " + fin->symbol);
+  if (!fin->mutable_ && !this->override &&
+      !(this->reference && !fin->type.isReference)) {
+    generator.alert("cannot assign to const " + fin->symbol);
   }
 
   mov2->logicalLine = this->logicalLine;
@@ -154,6 +155,10 @@ gen::GenerationResult const Assign::generate(gen::CodeGenerator &generator) {
   file << std::get<3>(resolved);
   if (this->modList.count == 0)
     gen::scope::ScopeManager::getInstance()->addAssign(fin->symbol);
+
+  if (this->modList.count == 0 && this->reference) {
+    gen::scope::ScopeManager::getInstance()->get(fin->symbol);
+  }
 
   if (generator.TypeList[fin->type.typeName] == nullptr) {
     auto t = new ast::Type();

--- a/src/Parser/AST/Statements/Assign.cpp
+++ b/src/Parser/AST/Statements/Assign.cpp
@@ -44,8 +44,8 @@ gen::GenerationResult const Assign::generate(gen::CodeGenerator &generator) {
   auto fin = symbol;
 
   if (symbol->type.isReference) {
-    const auto var = dynamic_cast<ast::Var *>(this->expr);
     if (this->to) {
+      const auto var = dynamic_cast<ast::Var *>(this->expr);
       if (!var) {
         generator.alert("A reference can only point to an lvalue");
       }
@@ -55,6 +55,8 @@ gen::GenerationResult const Assign::generate(gen::CodeGenerator &generator) {
       ref->modList = var->modList;
       ref->logicalLine = var->logicalLine;
       this->expr = ref;
+    } else {
+      this->reference = true;
     }
   }
 

--- a/src/Parser/AST/Statements/Call.cpp
+++ b/src/Parser/AST/Statements/Call.cpp
@@ -355,7 +355,22 @@ gen::GenerationResult const Call::generate(gen::CodeGenerator &generator) {
   while (this->Args.trail() > 0) {
     args.push(this->Args.touch());
     ast::Expr *rem = this->Args.touch();
-    gen::Expr exp = generator.GenExpr(this->Args.shift(), file);
+    ast::Expr *arg = this->Args.shift();
+    // check if the argument is a reference
+    if (checkArgs) {
+      if (func->argTypes.at(i).isReference) {
+        auto toReg = new ast::Reference();
+        auto var = dynamic_cast<ast::Var *>(arg);
+        if (!var) {
+          generator.alert("A reference can only point to an lvalue");
+        }
+        toReg->Ident = var->Ident;
+        toReg->modList = var->modList;
+        toReg->logicalLine = var->logicalLine;
+        arg = toReg;
+      }
+    }
+    gen::Expr exp = generator.GenExpr(arg, file);
     if (!exp.passable)
       generator.alert("Cannot pass an lvalue of safe type " + exp.type +
                       " to a function");

--- a/src/Parser/AST/Statements/Call.cpp
+++ b/src/Parser/AST/Statements/Call.cpp
@@ -361,6 +361,23 @@ gen::GenerationResult const Call::generate(gen::CodeGenerator &generator) {
       if (func->argTypes.at(i).isReference) {
         auto toReg = new ast::Reference();
         auto var = dynamic_cast<ast::Var *>(arg);
+        auto sym = gen::scope::ScopeManager::getInstance()->get(var->Ident);
+        if (!sym) {
+          sym = generator.GlobalSymbolTable.search<std::string>(
+              gen::utils::searchSymbol, var->Ident);
+        }
+
+        if (!sym) {
+          generator.alert("cannot find symbol: " + var->Ident);
+        }
+        if (sym->mutable_ == false && func->mutability[i]) {
+          generator.alert(
+              "cannot pass a const reference to a mutable "
+              "argument: " +
+              var->Ident);
+        } else if (func->mutability[i]) {
+          gen::scope::ScopeManager::getInstance()->addAssign(sym->symbol);
+        }
         if (!var) {
           generator.alert("A reference can only point to an lvalue");
         }

--- a/src/Parser/AST/Statements/DecAssign.cpp
+++ b/src/Parser/AST/Statements/DecAssign.cpp
@@ -19,6 +19,19 @@ gen::GenerationResult const DecAssign::generate(gen::CodeGenerator &generator) {
   ast::Declare *dec = this->declare;
   if (!generator.globalScope) {
     if (generator.scope == nullptr || generator.inFunction) {
+      if (dec->type.isReference) {
+        auto var = dynamic_cast<ast::Var *>(this->expr);
+        if (!var) {
+          generator.alert("A reference can only point to an lvalue");
+        }
+        // create a reference rather than a var
+        ast::Reference *ref = new ast::Reference();
+        ref->Ident = var->Ident;
+        ref->modList = var->modList;
+        ref->logicalLine = var->logicalLine;
+        this->expr = ref;
+      }
+
       auto mov = new asmc::Mov();
       mov->logicalLine = this->logicalLine;
       gen::Expr expr = generator.GenExpr(this->expr, file, dec->type.size);

--- a/src/Parser/AST/Statements/Function.cpp
+++ b/src/Parser/AST/Statements/Function.cpp
@@ -10,7 +10,8 @@ Function::Function(const string &ident, const ScopeMod &scope, const Type &type,
                    parse::Parser &parser)
     : scope(scope), type(type), op(op), scopeName(scopeName) {
   this->ident.ident = ident;
-  this->args = parser.parseArgs(tokens, ',', ')', this->argTypes, this->req);
+  this->args = parser.parseArgs(tokens, ',', ')', this->argTypes, this->req,
+                                this->mutability);
 
   if (dynamic_cast<lex::OpSym *>(tokens.peek()) != nullptr) {
     auto sym = *dynamic_cast<lex::OpSym *>(tokens.peek());

--- a/src/Parser/Parser.cpp
+++ b/src/Parser/Parser.cpp
@@ -214,6 +214,7 @@ ast::Statement *parse::Parser::parseStmt(
       const auto refSym = dynamic_cast<lex::OpSym *>(tokens.peek());
       if (refSym && refSym->Sym == '&') {
         type.isReference = true;
+        type.refSize = type.size;
         type.size = asmc::QWord;
         tokens.pop();
       }
@@ -605,6 +606,7 @@ ast::Statement *parse::Parser::parseArgs(
       const auto refSym = dynamic_cast<lex::OpSym *>(tokens.peek());
       if (refSym && refSym->Sym == '&') {
         dec->type.isReference = true;
+        dec->type.refSize = dec->type.size;
         dec->type.size = asmc::QWord;
         tokens.pop();
       }


### PR DESCRIPTION
This pull request introduces a new reference type designed to streamline the handling of lvalues by automatically storing pointers and managing dereferencing operations. The goal is to simplify syntax and improve code readability and maintainability, particularly in scenarios involving direct manipulations of memory addresses and references.

### Key Features:

Automatic Pointer Storage: When an lvalue is assigned to the new reference type, the underlying implementation automatically stores a pointer to the lvalue, eliminating the need for explicit pointer management by the developer.
Seamless Dereferencing: Accessing the value of the new reference type automatically dereferences the stored pointer, providing direct access to the target value without additional syntax.
Example Usage:

```
int a = 10;
int& number = a; // The new reference type automatically handles the pointer to 'a'
```
### Benefits:

- Simplified Syntax: Reduces the boilerplate associated with pointer and reference management, making the code more intuitive and less error-prone.
- Enhanced Readability: Makes it easier to understand at a glance what operations are being performed on variables, especially in complex expressions or algorithms.
- Increased Safety: By abstracting away the manual handling of pointers and dereferencing, the likelihood of common errors, such as dereferencing null pointers or memory leaks, is reduced.