### PR TITLE
Fix Catch2 build errors by including cstdint

### DIFF
--- a/Lib/Catch2/src/catch2/catch_test_case_info.hpp
+++ b/Lib/Catch2/src/catch2/catch_test_case_info.hpp
@@ -17,6 +17,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/Lib/Catch2/src/catch2/internal/catch_string_manip.hpp
+++ b/Lib/Catch2/src/catch2/internal/catch_string_manip.hpp
@@ -11,6 +11,7 @@
 #include <catch2/internal/catch_stringref.hpp>
 
 #include <string>
+#include <cstdint>
 #include <iosfwd>
 #include <vector>
 

--- a/Lib/Catch2/src/catch2/internal/catch_xmlwriter.cpp
+++ b/Lib/Catch2/src/catch2/internal/catch_xmlwriter.cpp
@@ -12,6 +12,7 @@
 #include <catch2/internal/catch_xmlwriter.hpp>
 
 #include <iomanip>
+#include <cstdint>
 #include <type_traits>
 
 namespace Catch {


### PR DESCRIPTION
## Summary
- ensure Catch2 headers include `<cstdint>` so standard integer types are defined

## Testing
- `make -j2`

------
https://chatgpt.com/codex/tasks/task_e_683fc54703d88328a3970ed0565599d9