### PR TITLE
Fix missing token line numbers

### DIFF
--- a/src/CodeGenerator/CodeGenerator.cpp
+++ b/src/CodeGenerator/CodeGenerator.cpp
@@ -920,6 +920,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
     ast::StringLiteral str = *dynamic_cast<ast::StringLiteral *>(expr);
     asmc::StringLiteral *strLit = new asmc::StringLiteral();
     asmc::Label *label = new asmc::Label();
+    strLit->logicalLine = this->logicalLine;
+    label->logicalLine = this->logicalLine;
     if (this->scope == nullptr)
       label->label = ".str" + this->nameTable.head->data.ident.ident +
                      std::to_string(this->labelCount);
@@ -1016,6 +1018,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
     ast::FloatLiteral *floatLit = dynamic_cast<ast::FloatLiteral *>(expr);
     asmc::FloatLiteral *fltLit = new asmc::FloatLiteral();
     asmc::Label *label = new asmc::Label();
+    fltLit->logicalLine = this->logicalLine;
+    label->logicalLine = this->logicalLine;
     if (this->scope == nullptr)
       label->label = ".float" + this->nameTable.head->data.ident.ident +
                      std::to_string(this->labelCount);
@@ -2064,7 +2068,11 @@ asmc::File gen::CodeGenerator::GenSTMT(ast::Statement *STMT) {
   this->logicalLine = STMT->logicalLine;
 
   if (STMT->locked)
-    OutputFile.text.push(new asmc::nop());
+    {
+      auto *inst = new asmc::nop();
+      inst->logicalLine = this->logicalLine;
+      OutputFile.text.push(inst);
+    }
   else
     OutputFile << STMT->generate(*this).file;
 
@@ -2074,7 +2082,11 @@ asmc::File gen::CodeGenerator::GenSTMT(ast::Statement *STMT) {
 asmc::File gen::CodeGenerator::ImportsOnly(ast::Statement *STMT) {
   asmc::File OutputFile = asmc::File();
   if (STMT->locked)
-    OutputFile.text.push(new asmc::nop());
+    {
+      auto *inst = new asmc::nop();
+      inst->logicalLine = STMT->logicalLine;
+      OutputFile.text.push(inst);
+    }
   else if (dynamic_cast<ast::Sequence *>(STMT) != nullptr) {
     this->ImportsOnly(dynamic_cast<ast::Sequence *>(STMT)->Statement1);
     this->ImportsOnly(dynamic_cast<ast::Sequence *>(STMT)->Statement2);

--- a/src/Parser/Parser.cpp
+++ b/src/Parser/Parser.cpp
@@ -584,15 +584,18 @@ ast::Statement *parse::Parser::parseStmt(
           // lets write everythig back to the tokens...
           auto s = new lex::OpSym();
           s->Sym = sym.Sym;
+          s->lineCount = sym.lineCount;
           tokens.push(s);
           for (int i = 0; i < modList.size(); i++) {
             auto s = new lex::LObj();
             s->meta = modList.pop();
+            s->lineCount = sym.lineCount;
             tokens.push(s);
           }
 
           auto name = new lex::LObj();
           name->meta = obj.meta;
+          name->lineCount = obj.lineCount;
           tokens.push(name);
 
           auto ret = new ast::Return();
@@ -621,6 +624,7 @@ ast::Statement *parse::Parser::parseStmt(
         if (!opSym || opSym->Sym != ';') {
           auto semicolon = new lex::OpSym();
           semicolon->Sym = ';';
+          semicolon->lineCount = tokens.peek()->lineCount;
           tokens.push(semicolon);
         }
       }
@@ -684,6 +688,7 @@ ast::Statement *parse::Parser::parseStmt(
           if (!els || els->meta != "else") {
             auto semicolon = new lex::OpSym();
             semicolon->Sym = ';';
+            semicolon->lineCount = tokens.peek()->lineCount;
             tokens.push(semicolon);
           }
         }

--- a/src/Scanner.cpp
+++ b/src/Scanner.cpp
@@ -201,30 +201,36 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input) {
     } else if (input[i] == ';') {
       auto semi = new OpSym;
       semi->Sym = input[i];
+      semi->lineCount = lineCount;
       tokens.push(semi);
       i++;
     } else if (input[i] == '?') {
       auto Ref = new lex::Ref;
+      Ref->lineCount = lineCount;
       tokens << Ref;
       i++;
     } else if (input[i] == '(') {
       auto cPrenth = new OpSym;
       cPrenth->Sym = input[i];
+      cPrenth->lineCount = lineCount;
       tokens.push(cPrenth);
       i++;
     } else if (input[i] == ')') {
       auto cPrenth = new OpSym;
       cPrenth->Sym = input[i];
+      cPrenth->lineCount = lineCount;
       tokens.push(cPrenth);
       i++;
     } else if (input[i] == '{') {
       auto cPrenth = new OpSym;
       cPrenth->Sym = input[i];
+      cPrenth->lineCount = lineCount;
       tokens.push(cPrenth);
       i++;
     } else if (input[i] == '}') {
       lex::OpSym *cPrenth = new OpSym;
       cPrenth->Sym = input[i];
+      cPrenth->lineCount = lineCount;
       tokens.push(cPrenth);
       i++;
     } else if (input[i] == '=') {
@@ -232,10 +238,12 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input) {
         auto equ = new lex::Symbol;
         equ->meta = "==";
         i++;
+        equ->lineCount = lineCount;
         tokens << equ;
       } else {
         auto equ = new OpSym;
         equ->Sym = input[i];
+        equ->lineCount = lineCount;
         tokens << equ;
       }
       i++;
@@ -245,15 +253,19 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input) {
       if (input[i + 1] == '<') {
         auto opSym = new lex::OpSym;
         opSym->Sym = '<';
+        opSym->lineCount = lineCount;
         tokens << opSym;
         free(sym);
         i++;
       } else if (input[i + 1] == '=') {
         sym->meta = "<=";
+        sym->lineCount = lineCount;
         tokens << sym;
         i++;
-      } else
+      } else {
+        sym->lineCount = lineCount;
         tokens << sym;
+      }
       i++;
     } else if (input[i] == '>') {
       auto *sym = new lex::Symbol;
@@ -261,15 +273,19 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input) {
       if (input[i + 1] == '>') {
         auto *opSym = new lex::OpSym;
         opSym->Sym = '>';
+        opSym->lineCount = lineCount;
         free(sym);
         tokens << opSym;
         i++;
       } else if (input[i + 1] == '=') {
         sym->meta = ">=";
+        sym->lineCount = lineCount;
         tokens << sym;
         i++;
-      } else
+      } else {
+        sym->lineCount = lineCount;
         tokens << sym;
+      }
       i++;
     } else if (input[i] == '|') {
       auto *sym = new lex::OpSym;
@@ -277,87 +293,105 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input) {
       if (input[i + 1] == '|') {
         auto opSym = new lex::Symbol;
         opSym->meta = "||";
+        opSym->lineCount = lineCount;
         free(sym);
         tokens << opSym;
         i++;
-      } else
+      } else {
+        sym->lineCount = lineCount;
         tokens << sym;
+      }
       i++;
     } else if (input[i] == '!') {
       if (input[i + 1] == '=') {
         auto equ = new lex::Symbol;
         equ->meta = "!=";
         i++;
+        equ->lineCount = lineCount;
         tokens << equ;
       } else {
         auto equ = new OpSym;
         equ->Sym = input[i];
+        equ->lineCount = lineCount;
         tokens << equ;
       }
       i++;
     } else if (input[i] == ',') {
       auto com = new OpSym;
       com->Sym = input[i];
+      com->lineCount = lineCount;
       tokens.push(com);
       i++;
     } else if (input[i] == '+') {
       auto add = new OpSym;
       add->Sym = input[i];
+      add->lineCount = lineCount;
       tokens.push(add);
       i++;
     } else if (input[i] == '[') {
       auto add = new OpSym;
       add->Sym = input[i];
+      add->lineCount = lineCount;
       tokens.push(add);
       i++;
     } else if (input[i] == ']') {
       auto add = new OpSym;
       add->Sym = input[i];
+      add->lineCount = lineCount;
       tokens.push(add);
       i++;
     } else if (input[i] == '*') {
       auto mul = new OpSym;
       mul->Sym = input[i];
+      mul->lineCount = lineCount;
       tokens << mul;
       i++;
     } else if (input[i] == '^') {
       auto carrot = new OpSym;
       carrot->Sym = input[i];
+      carrot->lineCount = lineCount;
       tokens << carrot;
       i++;
     } else if (input[i] == '%') {
       auto mul = new OpSym;
       mul->Sym = input[i];
+      mul->lineCount = lineCount;
       tokens << mul;
       i++;
     } else if (input[i] == ':') {
       auto col = new OpSym;
       col->Sym = input[i];
+      col->lineCount = lineCount;
       tokens << col;
       i++;
     } else if (input[i] == '@') {
       auto at = new OpSym;
       at->Sym = input[i];
+      at->lineCount = lineCount;
       tokens << at;
       i++;
     } else if (input[i] == '.') {
       auto mul = new OpSym;
       mul->Sym = input[i];
+      mul->lineCount = lineCount;
       tokens << mul;
       i++;
     } else if (input[i] == '/') {
       auto div = new OpSym;
       div->Sym = input[i];
+      div->lineCount = lineCount;
       tokens << div;
       i++;
     } else if (input[i] == '&') {
       auto andBit = new OpSym;
       andBit->Sym = input[i];
+      andBit->lineCount = lineCount;
       tokens << andBit;
       i++;
     } else if (input[i] == '$') {
       auto dollar = new OpSym;
       dollar->Sym = input[i];
+      dollar->lineCount = lineCount;
       tokens << dollar;
       i++;
     } else {


### PR DESCRIPTION
## Summary
- set `lineCount` for more Scanner tokens to improve debugging accuracy
- ensure Parser-injected tokens copy nearby line numbers
- preserve line numbers for generated nop instructions and data labels

## Testing
- `cmake -B build -S .`
- `cmake --build build --target test`
- `./bin/test`

------
https://chatgpt.com/codex/tasks/task_e_683fd8bd675083289bca7bce7f819aa2