### PR TITLE
Fix template string placeholder for raw address

### DIFF
--- a/libraries/std/src/String.af
+++ b/libraries/std/src/String.af
@@ -927,7 +927,7 @@ export string fString(const string fmt, * adr args) {
         if fmt.at(i) == '%' {
             i++;
             if fmt.at(i) == 'a' {
-                newString = newString + new String(args as adr);
+                newString = newString + new string(args as adr);
                 args = args + adr;
             } else if fmt.at(i) == 'c' {
                 newString = newString.push(args as char);


### PR DESCRIPTION
## Summary
- resolve incorrect `String` usage when handling `%a` placeholder in `fString`

## Testing
- `cmake -S . -B build`
- `cmake --build build -j2`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_6841ab5430688328bc625f0d4ef0f0e0