### PR TITLE
Optimize generated binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 add_subdirectory(Lib/Catch2)
 
 set (CMAKE_CXX_STANDARD 17)
-set (GCC_COMPILER_FLAGS -ggdb -g -fpermissive)
+set (GCC_COMPILER_FLAGS -O3 -march=native -flto -fpermissive)
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ../bin)
 project(aflat VERSION 1.1.0)
 
@@ -14,8 +14,9 @@ file(GLOB_RECURSE aflat_SRC
 find_package(Boost 1.71.0 REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
-add_definitions(${GCC_COMPILER_FLAGS})
+add_compile_options(${GCC_COMPILER_FLAGS})
 add_executable(aflat ${aflat_SRC})
+target_link_options(aflat PRIVATE -flto)
 
 target_include_directories(aflat PRIVATE include/) 
 
@@ -32,3 +33,4 @@ message (STATUS ${testing_Modules})
 add_executable(test ${testing_Modules})
 target_include_directories(test PRIVATE include/)
 target_link_libraries(test PRIVATE Catch2::Catch2WithMain)
+target_link_options(test PRIVATE -flto)

--- a/include/ASM.hpp
+++ b/include/ASM.hpp
@@ -291,6 +291,7 @@ class File {
   void operator<<(asmc::File file);
   void operator>>(asmc::File file);
   void cstitch(asmc::File file);
+  void optimize();
   void collect();
   File();
 };

--- a/include/CodeGenerator/CodeGenerator.hpp
+++ b/include/CodeGenerator/CodeGenerator.hpp
@@ -74,7 +74,7 @@ class Enum : public Type {
     std::string name;
     int value;
     EnumValue() = default;
-    EnumValue(std::string name, int value) : name(name), value(value){};
+    EnumValue(std::string name, int value) : name(name), value(value) {};
   };
 
   Enum();

--- a/include/CompilerUtils.hpp
+++ b/include/CompilerUtils.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include <string>
+
+namespace compilerutils {
+
+std::string buildCompileCmd(const std::string &srcPath,
+                            const std::string &destPath,
+                            bool debug);
+
+std::string buildLinkCmd(const std::string &output,
+                         const std::string &linkerList,
+                         bool debug);
+
+}  // namespace compilerutils

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 CXX       := g++
-CXX_FLAGS := -std=c++17 -ggdb -g -fpermissive
+CXX_FLAGS := -std=c++17 -O3 -march=native -flto -fpermissive
 
 BIN     := bin
 SRC     := src

--- a/src/ASM.cpp
+++ b/src/ASM.cpp
@@ -404,6 +404,26 @@ void asmc::File::collect() {
     this->cstitch(*this->lambdas);
     delete this->lambdas;
   }
+  this->optimize();
+}
+
+void asmc::File::optimize() {
+  links::LinkedList<asmc::Instruction *> optimized;
+  while (this->text.head != nullptr) {
+    auto inst = this->text.pop();
+    bool skip = false;
+    if (dynamic_cast<asmc::nop *>(inst) != nullptr) {
+      skip = true;
+    } else if (auto mov = dynamic_cast<asmc::Mov *>(inst); mov != nullptr) {
+      if (mov->from == mov->to) skip = true;
+    }
+    if (skip) {
+      delete inst;
+    } else {
+      optimized.append(inst);
+    }
+  }
+  this->text = optimized;
 }
 
 asmc::File::File() {

--- a/src/CompilerUtils.cpp
+++ b/src/CompilerUtils.cpp
@@ -1,0 +1,27 @@
+#include "CompilerUtils.hpp"
+
+namespace compilerutils {
+
+std::string buildCompileCmd(const std::string &srcPath,
+                            const std::string &destPath,
+                            bool debug) {
+  std::string flags;
+  if (debug)
+    flags = "-g -no-pie -z noexecstack -S -lefence ";
+  else
+    flags = "-O3 -march=native -S -no-pie -z noexecstack ";
+  return "gcc " + flags + srcPath + " -o " + destPath;
+}
+
+std::string buildLinkCmd(const std::string &output,
+                         const std::string &linkerList,
+                         bool debug) {
+  std::string flags;
+  if (debug)
+    flags = "-O0 -g -no-pie -z noexecstack -o ";
+  else
+    flags = "-O3 -march=native -no-pie -z noexecstack -o ";
+  return "gcc " + flags + output + " " + linkerList;
+}
+
+}  // namespace compilerutils

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 #include "Parser/Parser.hpp"
 #include "PreProcessor.hpp"
 #include "Scanner.hpp"
+#include "CompilerUtils.hpp"
 
 std::string preProcess(std::string input);
 std::string getExePath();
@@ -507,13 +508,9 @@ void ensureBinPath(const std::string &path,
 }
 
 bool compileCFile(const std::string &path, bool debug) {
-  std::string cmd;
-  if (debug)
-    cmd = "gcc -g -no-pie -z noexecstack -S -lefence ./src/" + path +
-          ".c -o ./bin/" + path + ".s";
-  else
-    cmd = "gcc -S -no-pie -z noexecstack ./src/" + path + ".c -o ./bin/" +
-          path + ".s";
+  std::string src = "./src/" + path + ".c";
+  std::string dst = "./bin/" + path + ".s";
+  std::string cmd = compilerutils::buildCompileCmd(src, dst, debug);
   return system(cmd.c_str()) == 0;
 }
 
@@ -611,11 +608,8 @@ bool runConfig(cfg::Config &config, const std::string &libPath, char pmode) {
     ofile = "./bin/a.test ";
   };
 
-  auto gcc = "gcc -no-pie -z noexecstack -o " + ofile + " " + linkerList;
-  if (config.debug) {
-    gcc = "gcc -O0 -g -no-pie -z noexecstack -o " + ofile + " " + linkerList;
-  }
-
+  std::string gcc =
+      compilerutils::buildLinkCmd(ofile, linkerList, config.debug);
   system(gcc.c_str());
   linker.erase(linker.begin(), linker.begin() + libs.size());
 

--- a/test/test_ASM.cpp
+++ b/test/test_ASM.cpp
@@ -24,3 +24,29 @@ TEST_CASE("Register get sizes", "[asm]") {
   REQUIRE(r.get(asmc::Word) == "%ax");
   REQUIRE(r.get(asmc::Byte) == "%al");
 }
+
+TEST_CASE("ASM File optimize removes redundant moves and nops", "[asm]") {
+  asmc::File f;
+  auto *movSame = new asmc::Mov();
+  movSame->from = "%rax";
+  movSame->to = "%rax";
+  movSame->size = asmc::QWord;
+  f.text.push(movSame);
+
+  auto *n = new asmc::nop();
+  f.text.push(n);
+
+  auto *mov = new asmc::Mov();
+  mov->from = "%rax";
+  mov->to = "%rbx";
+  mov->size = asmc::QWord;
+  f.text.push(mov);
+
+  f.optimize();
+
+  REQUIRE(f.text.size() == 1);
+  auto *inst = f.text.peek();
+  auto *m = dynamic_cast<asmc::Mov *>(inst);
+  REQUIRE(m != nullptr);
+  REQUIRE(m->to == "%rbx");
+}

--- a/test/test_CompilerUtils.cpp
+++ b/test/test_CompilerUtils.cpp
@@ -1,0 +1,22 @@
+#include "CompilerUtils.hpp"
+#include "catch.hpp"
+
+TEST_CASE("compile command uses optimization when not debugging", "[compilerutils]") {
+  auto cmd = compilerutils::buildCompileCmd("a.c", "a.s", false);
+  REQUIRE(cmd.find("-O3") != std::string::npos);
+  REQUIRE(cmd.find("-march=native") != std::string::npos);
+  REQUIRE(cmd.find("-g") == std::string::npos);
+}
+
+TEST_CASE("link command uses optimization when not debugging", "[compilerutils]") {
+  auto cmd = compilerutils::buildLinkCmd("a.out", "foo.s", false);
+  REQUIRE(cmd.find("-O3") != std::string::npos);
+  REQUIRE(cmd.find("-march=native") != std::string::npos);
+  REQUIRE(cmd.find("-g") == std::string::npos);
+}
+
+TEST_CASE("debug flags omit optimizations", "[compilerutils]") {
+  auto cmd = compilerutils::buildLinkCmd("a.out", "foo.s", true);
+  REQUIRE(cmd.find("-g") != std::string::npos);
+  REQUIRE(cmd.find("-O3") == std::string::npos);
+}


### PR DESCRIPTION
## Summary
- introduce CompilerUtils to centralize gcc command generation
- compile and link generated code with `-O3 -march=native`
- add unit tests for CompilerUtils
- add ASM peephole optimizer removing redundant moves and nops

## Testing
- `cmake -S . -B build`
- `cmake --build build -- -j4`
- `./bin/test`
- `bash rebuild-libs.sh`
- `./bin/aflat run`


------
https://chatgpt.com/codex/tasks/task_e_6841d8d956d88328b62afbf03eed3657