### PR TITLE
Enable mixed class and function imports

### DIFF
--- a/Docs.md
+++ b/Docs.md
@@ -244,9 +244,11 @@ Returns the address of the variable
 
 ### import
 ```bnf
-<import> ::= import {<function>, <function>} from "path" under <ident>
-            | import <Class>, <Class> from "path";
-            | import * from "path" under <ident>; // try to avoid this
+<import> ::= import <item>, <item> from "path" [under <ident>]
+
+<item>   ::= {<function>, <function>}
+           | <Class>
+           | *
 ```
 Import functions or classes from modules;
 ## Expressions
@@ -692,6 +694,13 @@ int game() {
 };
 ```
 note -- if a class signs a contract, the base class must be imported before the child.
+
+#### Importing classes and functions together
+AFlat now allows mixing both forms in a single statement.
+example:
+```js
+import Player, {spawn} from "./src/GameEngin" under game;
+```
 
 
 The list of standard modules is as follows:

--- a/include/CodeGenerator/CodeGenerator.hpp
+++ b/include/CodeGenerator/CodeGenerator.hpp
@@ -74,7 +74,7 @@ class Enum : public Type {
     std::string name;
     int value;
     EnumValue() = default;
-    EnumValue(std::string name, int value) : name(name), value(value) {};
+    EnumValue(std::string name, int value) : name(name), value(value){};
   };
 
   Enum();

--- a/include/CompilerUtils.hpp
+++ b/include/CompilerUtils.hpp
@@ -4,11 +4,9 @@
 namespace compilerutils {
 
 std::string buildCompileCmd(const std::string &srcPath,
-                            const std::string &destPath,
-                            bool debug);
+                            const std::string &destPath, bool debug);
 
 std::string buildLinkCmd(const std::string &output,
-                         const std::string &linkerList,
-                         bool debug);
+                         const std::string &linkerList, bool debug);
 
 }  // namespace compilerutils

--- a/include/Parser/AST/Statements/Import.hpp
+++ b/include/Parser/AST/Statements/Import.hpp
@@ -11,9 +11,11 @@ class Import : public Statement {
   std::vector<std::string> imports;
   std::string path;
   std::string nameSpace;
-  bool classes = false;
+  bool hasClasses = false;
+  bool hasFunctions = false;
   Import() = default;
   Import(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser);
   gen::GenerationResult const generate(gen::CodeGenerator &generator);
+  gen::GenerationResult const generateClasses(gen::CodeGenerator &generator);
 };
 };  // namespace ast

--- a/src/CodeGenerator/CodeGenerator.cpp
+++ b/src/CodeGenerator/CodeGenerator.cpp
@@ -2095,7 +2095,12 @@ asmc::File gen::CodeGenerator::ImportsOnly(ast::Statement *STMT) {
     this->ImportsOnly(dynamic_cast<ast::Sequence *>(STMT)->Statement2);
   } else if (dynamic_cast<ast::Import *>(STMT) != nullptr) {
     auto imp = dynamic_cast<ast::Import *>(STMT);
-    if (imp->classes) imp->generate(*this);
+    if (imp->hasClasses) {
+      if (imp->hasFunctions)
+        imp->generateClasses(*this);
+      else
+        imp->generate(*this);
+    }
   }
   return OutputFile;
 }

--- a/src/Parser/AST/Statements/Import.cpp
+++ b/src/Parser/AST/Statements/Import.cpp
@@ -12,10 +12,10 @@
 namespace ast {
 Import::Import(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
   this->logicalLine = tokens.peek()->lineCount;
-  auto sym = dynamic_cast<lex::OpSym *>(tokens.peek());
-  if (sym != nullptr) {
-    this->classes = false;
-    if (sym->Sym == '{') {
+  while (true) {
+    auto sym = dynamic_cast<lex::OpSym *>(tokens.peek());
+    if (sym != nullptr && sym->Sym == '{') {
+      this->hasFunctions = true;
       do {
         tokens.pop();
         auto importObj = dynamic_cast<lex::LObj *>(tokens.pop());
@@ -36,23 +36,14 @@ Import::Import(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
             "Line: " + std::to_string(tokens.peek()->lineCount) +
             " Expected }");
       }
-    } else if (sym->Sym == '*') {
+    } else if (sym != nullptr && sym->Sym == '*') {
+      this->hasFunctions = true;
       tokens.pop();
       this->imports.push_back("*");
-    } else
-      throw err::Exception("Line: " + std::to_string(tokens.peek()->lineCount) +
-                           " Unexpected Token");
-  } else {
-    bool first = true;
-    this->classes = true;
-    do {
-      if (!first)
-        tokens.pop();
-      else
-        first = false;
-
+    } else {
       auto nt = dynamic_cast<lex::LObj *>(tokens.peek());
       if (nt != nullptr) {
+        this->hasClasses = true;
         this->imports.push_back(nt->meta);
         auto t = ast::Type();
         t.size = asmc::QWord;
@@ -61,12 +52,16 @@ Import::Import(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
         parser.typeList << t;
         tokens.pop();
       } else {
-        throw err::Exception(
-            "Line: " + std::to_string(tokens.peek()->lineCount) +
-            " Expected Ident");
+        break;
       }
-    } while (dynamic_cast<lex::OpSym *>(tokens.peek()) != nullptr &&
-             dynamic_cast<lex::OpSym *>(tokens.peek())->Sym == ',');
+    }
+
+    if (dynamic_cast<lex::OpSym *>(tokens.peek()) != nullptr &&
+        dynamic_cast<lex::OpSym *>(tokens.peek())->Sym == ',') {
+      tokens.pop();
+      continue;
+    }
+    break;
   }
 
   // check from from keyword
@@ -161,7 +156,66 @@ gen::GenerationResult const Import::generate(gen::CodeGenerator &generator) {
       generator.alert("Identifier " + ident + " not found to import");
     OutputFile << generator.GenSTMT(statement);
   }
-  if (!this->classes) generator.nameSpaceTable.insert(this->nameSpace, id);
+  if (this->hasFunctions)
+    generator.nameSpaceTable.insert(this->nameSpace, id);
+  return {OutputFile, std::nullopt};
+}
+
+gen::GenerationResult const Import::generateClasses(
+    gen::CodeGenerator &generator) {
+  auto OutputFile = asmc::File();
+  if (this->path.find("./") == std::string::npos) {
+    this->path = gen::utils::getLibPath("src") + this->path;
+  };
+
+  if (this->path.substr(this->path.length() - 3, 3) != ".af") {
+    this->path = this->path + ".af";
+  };
+
+  std::string id = this->path.substr(this->path.find_last_of("/") + 1);
+  id = id.substr(0, id.find_last_of("."));
+  ast::Statement *added;
+  if (generator.includedMemo.contains(this->path))
+    added = generator.includedMemo.get(this->path);
+  else {
+    std::ifstream file(this->path);
+    if (!file.is_open()) {
+      this->path = this->path.substr(0, this->path.find_last_of(".")) +
+                   "/mod.af";
+      file.open(this->path);
+      if (!file.is_open()) {
+        generator.alert("File " + this->path + " not found");
+        return {OutputFile, std::nullopt};
+      }
+    }
+
+    std::string text = std::string((std::istreambuf_iterator<char>(file)),
+                                   std::istreambuf_iterator<char>());
+    lex::Lexer l = lex::Lexer();
+    PreProcessor pp = PreProcessor();
+
+    auto tokens = l.Scan(pp.PreProcess(text, gen::utils::getLibPath("head")));
+    tokens.invert();
+    parse::Parser p = parse::Parser();
+    ast::Statement *statement = p.parseStmt(tokens);
+    auto Lowerer = parse::lower::Lowerer(statement);
+    added = statement;
+    generator.includedMemo.insert(this->path, added);
+    generator.ImportsOnly(added);
+  }
+
+  for (std::string ident : this->imports) {
+    ast::Statement *statement = gen::utils::extract(ident, added, id);
+    if (statement == nullptr) continue;
+    if (dynamic_cast<ast::Class *>(statement) == nullptr &&
+        dynamic_cast<ast::Enum *>(statement) == nullptr &&
+        dynamic_cast<ast::Transform *>(statement) == nullptr)
+      continue;
+    if (generator.includedClasses.contains(id + "::" + ident)) continue;
+    generator.includedClasses.insert(id + "::" + ident, nullptr);
+    OutputFile << generator.GenSTMT(statement);
+  }
+
   return {OutputFile, std::nullopt};
 }
 }  // namespace ast

--- a/src/main.af
+++ b/src/main.af
@@ -3,5 +3,6 @@
 import string, {print} from "String" under str;
 
 fn main() {
+    string value = "Aflat Bin";
     str.print("Aflat Bin\n");
 };

--- a/src/main.af
+++ b/src/main.af
@@ -1,7 +1,6 @@
 .needs <std>
 
-import string from "String";
-import {print} from "String" under str;
+import string, {print} from "String" under str;
 
 fn main() {
     str.print("Aflat Bin\n");

--- a/test/test_Import.cpp
+++ b/test/test_Import.cpp
@@ -1,0 +1,54 @@
+#include "Parser/Parser.hpp"
+#include "PreProcessor.hpp"
+#include "Scanner.hpp"
+#include "catch.hpp"
+#include "CodeGenerator/MockCodeGenerator.hpp"
+#include <fstream>
+#include <cstdio>
+
+TEST_CASE("Parser handles mixed import of classes and functions", "[parser]") {
+  lex::Lexer l;
+  PreProcessor pp;
+  auto code = pp.PreProcess("import Foo, {bar} from \"Mod\" under m;", "");
+  auto tokens = l.Scan(code);
+  tokens.invert();
+  parse::Parser p;
+  ast::Statement *stmt = p.parseStmt(tokens);
+  auto *seq = dynamic_cast<ast::Sequence *>(stmt);
+  REQUIRE(seq != nullptr);
+  auto *imp = dynamic_cast<ast::Import *>(seq->Statement1);
+  REQUIRE(imp != nullptr);
+  REQUIRE(imp->hasClasses);
+  REQUIRE(imp->hasFunctions);
+  REQUIRE(imp->imports.size() == 2);
+  REQUIRE(imp->imports[0] == "Foo");
+  REQUIRE(imp->imports[1] == "bar");
+}
+
+TEST_CASE("ImportsOnly ignores functions in mixed import", "[codegen]") {
+  std::ofstream mod("Temp.af");
+  mod << "class Foo {}\n";
+  mod << "export int bar() { return 0; };\n";
+  mod.close();
+
+  lex::Lexer l;
+  PreProcessor pp;
+  auto code = pp.PreProcess("import Foo, {bar} from \"./Temp\" under m;", "");
+  auto tokens = l.Scan(code);
+  tokens.invert();
+  parse::Parser p;
+  ast::Statement *stmt = p.parseStmt(tokens);
+  auto *seq = dynamic_cast<ast::Sequence *>(stmt);
+  REQUIRE(seq != nullptr);
+  auto *imp = dynamic_cast<ast::Import *>(seq->Statement1);
+  REQUIRE(imp != nullptr);
+
+  test::mockGen::CodeGenerator gen("mod", p, "");
+  gen.ImportsOnly(imp);
+
+  REQUIRE(gen.includedClasses.contains("Temp::Foo"));
+  REQUIRE_FALSE(gen.includedClasses.contains("Temp::bar"));
+  REQUIRE_FALSE(gen.nameSpaceTable.contains("m"));
+
+  std::remove("Temp.af");
+}


### PR DESCRIPTION
## Summary
- allow import statements to mix classes and functions
- update documentation for mixed imports
- test parser behaviour for new mixed import syntax
- add missing newline in Import.hpp
- only import classes when ImportsOnly encounters mixed imports
- verify ImportsOnly behavior with new unit test

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `../bin/test`


------
https://chatgpt.com/codex/tasks/task_e_684255bf759483289652d77c63863726