### PR TITLE
Add column metadata

### DIFF
--- a/include/CodeGenerator/Expr.hpp
+++ b/include/CodeGenerator/Expr.hpp
@@ -11,6 +11,9 @@ class Expr {
   std::string type = "";
   asmc::Size size;
   bool passable = true;
+  int logicalLine = 0;
+  int columnStart = 0;
+  int columnEnd = 0;
   Expr() = default;
 };
 }  // namespace gen

--- a/include/Exceptions.hpp
+++ b/include/Exceptions.hpp
@@ -3,12 +3,20 @@
 
 #include <string>
 
+namespace lex {
+class Token;
+}
+
 namespace err {
 class Exception {
  public:
   std::string errorMsg;
   explicit Exception(std::string msg);
+  Exception(std::string msg, int line, int columnStart, int columnEnd);
+  Exception(std::string msg, lex::Token *tok);
 };
+
+std::string formatLoc(int line, int columnStart, int columnEnd);
 }  // namespace err
 
 #endif  // ERR

--- a/include/Parser/AST.hpp
+++ b/include/Parser/AST.hpp
@@ -39,6 +39,8 @@ class Statement {
  public:
   bool locked = false;
   int logicalLine = 0;
+  int columnStart = 0;
+  int columnEnd = 0;
   virtual std::string toString() { return ""; };
   virtual gen::GenerationResult const generate(gen::CodeGenerator &generator) {
     asmc::File file;
@@ -126,7 +128,7 @@ class Type {
 
   Type() = default;
   Type(const std::string &typeName, const asmc::Size &size)
-      : typeName(typeName), size(size){};
+      : typeName(typeName), size(size) {};
 };
 
 class Arg {

--- a/include/Scanner.hpp
+++ b/include/Scanner.hpp
@@ -13,6 +13,8 @@ namespace lex {
 class Token {
  public:
   int lineCount;
+  int columnStart;
+  int columnEnd;
   virtual ~Token() = default;
 };
 

--- a/src/Exceptions.cpp
+++ b/src/Exceptions.cpp
@@ -1,3 +1,20 @@
 #include "Exceptions.hpp"
 
+#include "Scanner.hpp"
+
 err::Exception::Exception(std::string msg) { this->errorMsg = msg; }
+
+std::string err::formatLoc(int line, int columnStart, int columnEnd) {
+  std::string loc =
+      "Line: " + std::to_string(line) + " Col: " + std::to_string(columnStart);
+  if (columnEnd != columnStart) loc += "-" + std::to_string(columnEnd);
+  return loc;
+}
+
+err::Exception::Exception(std::string msg, int line, int columnStart,
+                          int columnEnd) {
+  this->errorMsg = formatLoc(line, columnStart, columnEnd) + " " + msg;
+}
+
+err::Exception::Exception(std::string msg, lex::Token *tok)
+    : Exception(msg, tok->lineCount, tok->columnStart, tok->columnEnd) {}

--- a/src/Parser/AST/Statements/Assign.cpp
+++ b/src/Parser/AST/Statements/Assign.cpp
@@ -10,6 +10,8 @@ Assign::Assign(const std::string &ident,
                links::LinkedList<std::string> modList,
                links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
   this->logicalLine = tokens.peek()->lineCount;
+  columnStart = tokens.peek()->columnStart;
+  columnEnd = tokens.peek()->columnEnd;
   if (dynamic_cast<lex::OpSym *>(tokens.peek()) != nullptr) {
     auto s2 = dynamic_cast<lex::OpSym *>(tokens.peek());
     if (s2->Sym == ':') {

--- a/src/Parser/AST/Statements/Break.cpp
+++ b/src/Parser/AST/Statements/Break.cpp
@@ -8,6 +8,8 @@ namespace ast {
  */
 Break::Break(links::LinkedList<lex::Token *> &tokens) {
   this->logicalLine = tokens.peek()->lineCount;
+  columnStart = tokens.peek()->columnStart;
+  columnEnd = tokens.peek()->columnEnd;
   if (dynamic_cast<lex::INT *>(tokens.peek()) != nullptr)
     this->level = std::stoi(dynamic_cast<lex::INT *>(tokens.pop())->value);
   else

--- a/src/Parser/AST/Statements/Class.cpp
+++ b/src/Parser/AST/Statements/Class.cpp
@@ -11,6 +11,8 @@ Class::Class(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser,
              std::vector<parse::Annotation> &annotations) {
   this->annotations = annotations;
   this->logicalLine = tokens.peek()->lineCount;
+  columnStart = tokens.peek()->columnStart;
+  columnEnd = tokens.peek()->columnEnd;
   if (dynamic_cast<lex::LObj *>(tokens.peek()) != nullptr) {
     auto ident = *dynamic_cast<lex::LObj *>(tokens.pop());
     this->ident.ident = ident.meta;

--- a/src/Parser/AST/Statements/Delete.cpp
+++ b/src/Parser/AST/Statements/Delete.cpp
@@ -9,9 +9,7 @@ namespace ast {
 Delete::Delete(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
   this->logicalLine = tokens.peek()->lineCount;
   auto ident = dynamic_cast<lex::LObj *>(tokens.pop());
-  if (ident == nullptr)
-    throw err::Exception("Line: " + std::to_string(tokens.peek()->lineCount) +
-                         " Expected Ident");
+  if (ident == nullptr) throw err::Exception("Expected Ident", tokens.peek());
 
   this->ident = ident->meta;
   links::LinkedList<std::string> modList;
@@ -22,13 +20,13 @@ Delete::Delete(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
       auto mod = *dynamic_cast<lex::LObj *>(tokens.pop());
       modList << mod.meta;
     } else
-      throw err::Exception("Expected, Ident after dot. on line " +
-                           std::to_string(sym->lineCount));
+      throw err::Exception("Expected Ident after dot.", tokens.peek());
     if (dynamic_cast<lex::OpSym *>(tokens.peek()) != nullptr) {
       sym = dynamic_cast<lex::OpSym *>(tokens.peek());
     } else
-      throw err::Exception("expected assignment operator got on line " +
-                           std::to_string(sym->lineCount) + " " + sym->Sym);
+      throw err::Exception(
+          "expected assignment operator got " + std::string(1, sym->Sym),
+          tokens.peek());
   }
 
   this->modList = modList;

--- a/src/Parser/AST/Statements/Enum.cpp
+++ b/src/Parser/AST/Statements/Enum.cpp
@@ -15,13 +15,11 @@ Enum::Enum(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
     auto ident = *dynamic_cast<lex::LObj *>(tokens.pop());
     this->Ident = ident.meta;
   } else
-    throw err::Exception("Line: " + std::to_string(tokens.peek()->lineCount) +
-                         " enum needs Ident");
+    throw err::Exception("enum needs Ident", tokens.peek());
 
   lex::OpSym *op = dynamic_cast<lex::OpSym *>(tokens.peek());
   if (!op || op->Sym != '{')
-    throw err::Exception("Line: " + std::to_string(tokens.peek()->lineCount) +
-                         " Unopened Enum");
+    throw err::Exception("Unopened Enum", tokens.peek());
 
   tokens.pop();
 
@@ -34,8 +32,7 @@ Enum::Enum(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
 
   op = dynamic_cast<lex::OpSym *>(tokens.peek());
   if (!op || op->Sym != '}')
-    throw err::Exception("Line: " + std::to_string(tokens.peek()->lineCount) +
-                         " Unclosed Enum");
+    throw err::Exception("Unclosed Enum", tokens.peek());
   tokens.pop();
   parser.typeList << ast::Type(this->Ident, asmc::DWord);
 }

--- a/src/Parser/AST/Statements/For.cpp
+++ b/src/Parser/AST/Statements/For.cpp
@@ -10,11 +10,9 @@ For::For(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
   auto sym = dynamic_cast<lex::OpSym *>(tokens.peek());
 
   if (sym == nullptr)
-    throw err::Exception("Line: " + std::to_string(tokens.peek()->lineCount) +
-                         " Unterminated for loop initializer");
+    throw err::Exception("Unterminated for loop initializer", tokens.peek());
   if (sym->Sym != ';')
-    throw err::Exception("Line: " + std::to_string(tokens.peek()->lineCount) +
-                         "unterminated for loop initializer");
+    throw err::Exception("unterminated for loop initializer", tokens.peek());
 
   tokens.pop();
 
@@ -22,11 +20,9 @@ For::For(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
 
   sym = dynamic_cast<lex::OpSym *>(tokens.peek());
   if (sym == nullptr)
-    throw err::Exception("Line: " + std::to_string(tokens.peek()->lineCount) +
-                         " Unterminated for loop condition");
+    throw err::Exception("Unterminated for loop condition", tokens.peek());
   if (sym->Sym != ';')
-    throw err::Exception("Line: " + std::to_string(tokens.peek()->lineCount) +
-                         "unterminated for loop condition");
+    throw err::Exception("unterminated for loop condition", tokens.peek());
   tokens.pop();
 
   this->increment = parser.parseStmt(tokens, true);
@@ -42,9 +38,7 @@ For::For(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
         tokens.pop();
         this->Run = parser.parseStmt(tokens);
       } else
-        throw err::Exception(
-            "Line: " + std::to_string(tokens.peek()->lineCount) +
-            " Unopened for loop body");
+        throw err::Exception("Unopened for loop body", tokens.peek());
     }
   } else
     this->Run = parser.parseStmt(tokens, true);

--- a/src/Parser/AST/Statements/Import.cpp
+++ b/src/Parser/AST/Statements/Import.cpp
@@ -22,9 +22,7 @@ Import::Import(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
         if (importObj != nullptr) {
           this->imports.push_back(importObj->meta);
         } else {
-          throw err::Exception(
-              "Line: " + std::to_string(tokens.peek()->lineCount) +
-              " Expected Ident");
+          throw err::Exception("Expected Ident", tokens.peek());
         }
       } while (dynamic_cast<lex::OpSym *>(tokens.peek()) != nullptr &&
                dynamic_cast<lex::OpSym *>(tokens.peek())->Sym == ',');
@@ -32,9 +30,7 @@ Import::Import(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
           dynamic_cast<lex::OpSym *>(tokens.peek())->Sym == '}') {
         tokens.pop();
       } else {
-        throw err::Exception(
-            "Line: " + std::to_string(tokens.peek()->lineCount) +
-            " Expected }");
+        throw err::Exception("Expected }", tokens.peek());
       }
     } else if (sym != nullptr && sym->Sym == '*') {
       this->hasFunctions = true;
@@ -67,8 +63,7 @@ Import::Import(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
   // check from from keyword
   lex::LObj *from = dynamic_cast<lex::LObj *>(tokens.pop());
   if (from == nullptr || from->meta != "from") {
-    throw err::Exception("Line: " + std::to_string(tokens.peek()->lineCount) +
-                         " Expected from");
+    throw err::Exception("Expected from", tokens.peek());
   };
 
   ast::StringLiteral *str =
@@ -76,8 +71,7 @@ Import::Import(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
   if (str != nullptr) {
     this->path = str->val;
   } else {
-    throw err::Exception("Line: " + std::to_string(tokens.peek()->lineCount) +
-                         " Expected StringLiteral");
+    throw err::Exception("Expected StringLiteral", tokens.peek());
   }
 
   // check for under keyword
@@ -90,9 +84,7 @@ Import::Import(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
         this->nameSpace = ident->meta;
         tokens.pop();
       } else {
-        throw err::Exception(
-            "Line: " + std::to_string(tokens.peek()->lineCount) +
-            " Expected Ident");
+        throw err::Exception("Expected Ident", tokens.peek());
       }
     }
   } else {
@@ -156,8 +148,7 @@ gen::GenerationResult const Import::generate(gen::CodeGenerator &generator) {
       generator.alert("Identifier " + ident + " not found to import");
     OutputFile << generator.GenSTMT(statement);
   }
-  if (this->hasFunctions)
-    generator.nameSpaceTable.insert(this->nameSpace, id);
+  if (this->hasFunctions) generator.nameSpaceTable.insert(this->nameSpace, id);
   return {OutputFile, std::nullopt};
 }
 
@@ -180,8 +171,8 @@ gen::GenerationResult const Import::generateClasses(
   else {
     std::ifstream file(this->path);
     if (!file.is_open()) {
-      this->path = this->path.substr(0, this->path.find_last_of(".")) +
-                   "/mod.af";
+      this->path =
+          this->path.substr(0, this->path.find_last_of(".")) + "/mod.af";
       file.open(this->path);
       if (!file.is_open()) {
         generator.alert("File " + this->path + " not found");

--- a/src/Parser/AST/Statements/Struct.cpp
+++ b/src/Parser/AST/Statements/Struct.cpp
@@ -10,16 +10,13 @@ Struct::Struct(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
     auto ident = *dynamic_cast<lex::LObj *>(tokens.pop());
     this->ident.ident = ident.meta;
   } else
-    throw err::Exception("Line: " + std::to_string(tokens.peek()->lineCount) +
-                         " struct needs Ident");
+    throw err::Exception("struct needs Ident", tokens.peek());
   if (dynamic_cast<lex::OpSym *>(tokens.peek()) != nullptr) {
     auto op = *dynamic_cast<lex::OpSym *>(tokens.pop());
     if (op.Sym != '{')
-      throw err::Exception("Line: " + std::to_string(tokens.peek()->lineCount) +
-                           " Unopened UDeffType");
+      throw err::Exception("Unopened UDeffType", tokens.peek());
   } else
-    throw err::Exception("Line: " + std::to_string(tokens.peek()->lineCount) +
-                         " Unopened UDeffType");
+    throw err::Exception("Unopened UDeffType", tokens.peek());
   this->statement = parser.parseStmt(tokens);
   parser.addType(this->ident.ident, asmc::Hard, asmc::QWord);
 }

--- a/src/Parser/AST/Statements/While.cpp
+++ b/src/Parser/AST/Statements/While.cpp
@@ -19,9 +19,9 @@ While::While(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
       tokens.pop();
       this->stmt = parser.parseStmt(tokens);
     } else
-      throw err::Exception("Line: " + std::to_string(sym->lineCount) +
-                           " un - opened while loop, expected '{' got " +
-                           sym->Sym + " instead");
+      throw err::Exception("un - opened while loop, expected '{' got " +
+                               std::string(1, sym->Sym),
+                           sym);
   } else
     this->stmt = parser.parseStmt(tokens, true);
 }

--- a/test/test_Scanner.cpp
+++ b/test/test_Scanner.cpp
@@ -9,6 +9,10 @@ TEST_CASE("Lexer scans identifiers and ints", "[scanner]") {
   auto *second = dynamic_cast<lex::INT *>(tokens.get(1));
   REQUIRE(first != nullptr);
   REQUIRE(first->meta == "foo");
+  REQUIRE(first->columnStart == 0);
+  REQUIRE(first->columnEnd == 2);
   REQUIRE(second != nullptr);
   REQUIRE(second->value == "123");
+  REQUIRE(second->columnStart == 4);
+  REQUIRE(second->columnEnd == 6);
 }


### PR DESCRIPTION
## Summary
- add helper to format location for errors
- overload err::Exception to attach line and column info
- propagate tokens to error messages in several statements
- test scanner column tracking

## Testing
- `find src include test -path ./Lib -prune -o -path ./test/catch.hpp -prune -o -regex '.*\.(cpp|hpp)' -exec clang-format -style=file -i {} \+ -exec git add {} \+`
- `make -j1` *(fails: rebuild-libs segfaults)*
- `./bin/aflat run` *(fails: semantic errors in main.af)*
- `./bin/a.test` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68426f55fd4c83288839219ec2f98ccd