### PR TITLE
Modernize C++ utilities

### DIFF
--- a/include/CompilerUtils.hpp
+++ b/include/CompilerUtils.hpp
@@ -3,10 +3,10 @@
 
 namespace compilerutils {
 
-std::string buildCompileCmd(const std::string &srcPath,
-                            const std::string &destPath, bool debug);
+std::string buildCompileCmd(std::string_view srcPath,
+                            std::string_view destPath, bool debug);
 
-std::string buildLinkCmd(const std::string &output,
-                         const std::string &linkerList, bool debug);
+std::string buildLinkCmd(std::string_view output,
+                         std::string_view linkerList, bool debug);
 
 }  // namespace compilerutils

--- a/src/CompilerUtils.cpp
+++ b/src/CompilerUtils.cpp
@@ -1,27 +1,26 @@
 #include "CompilerUtils.hpp"
+#include <string_view>
 
 namespace compilerutils {
 
-std::string buildCompileCmd(const std::string &srcPath,
-                            const std::string &destPath,
+std::string buildCompileCmd(std::string_view srcPath,
+                            std::string_view destPath,
                             bool debug) {
-  std::string flags;
-  if (debug)
-    flags = "-g -no-pie -z noexecstack -S -lefence ";
-  else
-    flags = "-O3 -march=native -S -no-pie -z noexecstack ";
-  return "gcc " + flags + srcPath + " -o " + destPath;
+  const std::string flags =
+      debug ? "-g -no-pie -z noexecstack -S -lefence "
+            : "-O3 -march=native -S -no-pie -z noexecstack ";
+  return std::string{"gcc "} + flags + std::string{srcPath} + " -o " +
+         std::string{destPath};
 }
 
-std::string buildLinkCmd(const std::string &output,
-                         const std::string &linkerList,
+std::string buildLinkCmd(std::string_view output,
+                         std::string_view linkerList,
                          bool debug) {
-  std::string flags;
-  if (debug)
-    flags = "-O0 -g -no-pie -z noexecstack -o ";
-  else
-    flags = "-O3 -march=native -no-pie -z noexecstack -o ";
-  return "gcc " + flags + output + " " + linkerList;
+  const std::string flags =
+      debug ? "-O0 -g -no-pie -z noexecstack -o "
+            : "-O3 -march=native -no-pie -z noexecstack -o ";
+  return std::string{"gcc "} + flags + std::string{output} + " " +
+         std::string{linkerList};
 }
 
 }  // namespace compilerutils


### PR DESCRIPTION
## Summary
- modernize CompilerUtils signatures to use `std::string_view`
- simplify flag selection logic
- replace index-based loops in ScopeManager with range-based or reverse iterators
- further modernize stack pop loops

## Testing
- `make -j2`
- `./bin/aflat run`
- `cmake --build build -j1`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_684658b846a48328b9e39c30b412a7a7