### PR TITLE
Resolve build warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 add_subdirectory(Lib/Catch2)
 
 set (CMAKE_CXX_STANDARD 17)
-set (GCC_COMPILER_FLAGS -O3 -march=native -flto -fpermissive)
+set (GCC_COMPILER_FLAGS -O3 -march=native -fpermissive)
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ../bin)
 project(aflat VERSION 1.1.0)
 
@@ -16,7 +16,7 @@ include_directories(${Boost_INCLUDE_DIRS})
 
 add_compile_options(${GCC_COMPILER_FLAGS})
 add_executable(aflat ${aflat_SRC})
-target_link_options(aflat PRIVATE -flto)
+# target_link_options(aflat PRIVATE -flto)
 
 target_include_directories(aflat PRIVATE include/) 
 
@@ -33,4 +33,4 @@ message (STATUS ${testing_Modules})
 add_executable(test ${testing_Modules})
 target_include_directories(test PRIVATE include/)
 target_link_libraries(test PRIVATE Catch2::Catch2WithMain)
-target_link_options(test PRIVATE -flto)
+# target_link_options(test PRIVATE -flto)

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 CXX       := g++
-CXX_FLAGS := -std=c++17 -O0 -march=native -flto -fpermissive -g
+CXX_FLAGS := -std=c++17 -O0 -march=native -fpermissive -g
 
 BIN     := bin
 SRC     := src

--- a/src/CodeGenerator/ScopeManage.cpp
+++ b/src/CodeGenerator/ScopeManage.cpp
@@ -21,7 +21,7 @@ void ScopeManager::reset() {
 }
 
 int ScopeManager::assign(std::string symbol, ast::Type type, bool mask,
-                         bool mut = true) {
+                         bool mut) {
   using namespace gen::utils;
   auto sym = gen::Symbol();
 
@@ -74,7 +74,7 @@ std::string removeTildes(const std::string &input) {
 }
 
 void ScopeManager::popScope(CodeGenerator *callback, asmc::File &OutputFile,
-                            bool fPop = false) {
+                            bool fPop) {
   using namespace gen::utils;
   int size = this->scopeStack.back();
   for (int i = 0; i < size; i++) {
@@ -196,7 +196,7 @@ std::vector<gen::Symbol> ScopeManager::getScope(const bool used) {
   return scope;
 };
 
-void ScopeManager::addAssign(std::string symbol, bool get = true) {
+void ScopeManager::addAssign(std::string symbol, bool get) {
   for (int i = this->stack.size() - 1; i >= 0; i--) {
     if (this->stack[i].symbol == symbol) {
       this->stack[i].assignCount++;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,7 +124,7 @@ int main(int argc, char *argv[]) {
       if (config.outPutFile[0] != '.' && config.outPutFile[1] != '/') {
         of = "./" + config.outPutFile;
       }
-      system(of.c_str());
+      [[maybe_unused]] int rc = system(of.c_str());
     }
     return 0;
   }
@@ -134,7 +134,7 @@ int main(int argc, char *argv[]) {
                         (std::istreambuf_iterator<char>()));
     cfg::Config config = cfg::getConfig(content);
     if (runConfig(config, libPathA, 't')) {
-      system("./bin/a.test");
+      [[maybe_unused]] int rc = system("./bin/a.test");
     }
     return 0;
   }
@@ -197,7 +197,7 @@ int main(int argc, char *argv[]) {
         "curl -s "
         "https://raw.githubusercontent.com/DeForestt/aflat/refs/heads/main/"
         "install.sh | bash";
-    system(update_command.c_str());
+    [[maybe_unused]] int rc = system(update_command.c_str());
     return 0;
   }
   if (value == "clean") {
@@ -221,7 +221,7 @@ int main(int argc, char *argv[]) {
         "https://aflat-server.fly.dev/"
         "api/package/" +
         gitRepo + " | bash";
-    system(install_command.c_str());
+    [[maybe_unused]] int rc = system(install_command.c_str());
   }
   std::string outputFile;
   if (argc == 2)
@@ -599,7 +599,7 @@ bool runConfig(cfg::Config &config, const std::string &libPath, char pmode) {
 
   std::string gcc =
       compilerutils::buildLinkCmd(ofile, linkerList, config.debug);
-  system(gcc.c_str());
+  [[maybe_unused]] int rc = system(gcc.c_str());
   linker.erase(linker.begin(), linker.begin() + libs.size());
 
   if (!config.asm_) {


### PR DESCRIPTION
## Summary
- clean up default argument warnings in `ScopeManage.cpp`
- drop LTO to avoid lto-wrapper warnings
- silence unused system() return value warnings

## Testing
- `make`
- `cmake --build build -j5`
- `cd build && ctest --output-on-failure` *(no tests were configured, so ran test binary)*
- `../bin/test`

------
https://chatgpt.com/codex/tasks/task_e_68477624fc608328b1237683909d9e51