### PR TITLE
Generate template types when resolving symbols

### DIFF
--- a/include/CodeGenerator/CodeGenerator.hpp
+++ b/include/CodeGenerator/CodeGenerator.hpp
@@ -193,6 +193,8 @@ class CodeGenerator {
                                       const std::vector<std::string> &types,
                                       std::string &newName,
                                       asmc::File &OutputFile);
+  void ensureTemplateType(const std::string &typeName,
+                          asmc::File &OutputFile);
   CodeGenerator(std::string moduleId, parse::Parser &parser,
                 const std::string &source = "");
   asmc::File *deScope(gen::Symbol &sym);

--- a/test/test_TemplateTypeGeneration.cpp
+++ b/test/test_TemplateTypeGeneration.cpp
@@ -1,0 +1,31 @@
+#include "CodeGenerator/MockCodeGenerator.hpp"
+#include "CodeGenerator/ScopeManager.hpp"
+#include "Parser/Parser.hpp"
+#include "Parser/AST/Statements/Sequence.hpp"
+#include "catch.hpp"
+
+TEST_CASE("resolveSymbol generates template types", "[templates]") {
+  auto sm = gen::scope::ScopeManager::getInstance();
+  sm->reset();
+
+  parse::Parser parser;
+  test::mockGen::CodeGenerator gen("mod", parser, "");
+
+  auto cls = new ast::Class();
+  cls->ident.ident = "Box";
+  cls->genericTypes.push_back("T");
+  cls->statement = new ast::Sequence();
+  gen.genericTypes["Box"] = cls;
+
+  ast::Type t;
+  t.typeName = "Box.int";
+  t.size = asmc::QWord;
+  sm->assign("x", t, false);
+
+  links::LinkedList<std::string> mods;
+  links::LinkedList<ast::Expr *> idx;
+  asmc::File file;
+  gen.resolveSymbol("x", mods, file, idx);
+
+  REQUIRE(gen.typeList["Box.int"] != nullptr);
+}


### PR DESCRIPTION
## Summary
- add helper `ensureTemplateType` to instantiate generic classes
- call helper when resolving symbols and handling call expressions
- test template type creation during symbol resolution

## Testing
- `make -j4`
- `cmake -S . -B build`
- `cmake --build build --target a.test`
- `./bin/a.test`

------
https://chatgpt.com/codex/tasks/task_e_684ce0603ee483289e2dc8f2cea0831e