### PR TITLE
Add generic Option utility

### DIFF
--- a/libraries/std/src/Utils/option.af
+++ b/libraries/std/src/Utils/option.af
@@ -1,0 +1,79 @@
+.needs <std>
+
+import Function from "Utils/Functions";
+import Map from "Utils/Map";
+import Option from "Utils/Option";
+import string from "String";
+
+types(A)
+safe dynamic class option {
+    private A value = value;
+    private mutable bool hasValue = hasValue;
+    private mutable int refcount = 1;
+
+    fn get() -> Self {
+        my.refcount = my.refcount + 1;
+        return my;
+    };
+
+    fn endScope() {
+        my.refcount = my.refcount - 1;
+        if my.refcount == 0 {
+            delete my;
+        };
+        return;
+    };
+
+    fn init(const bool hasValue, *const A value) -> Self {
+        return my;
+    };
+
+    fn resolve(const Function acc, const Function rej, *const any arg, *const any arg2) {
+        if my.hasValue
+            return acc(my.value, arg, arg2)
+        else
+            return rej(NULL, arg, arg2);
+    };
+
+    fn orElse(const Function onNone, *const any arg) -> A {
+        if my.hasValue
+            return my.value
+        else
+            return onNone(NULL, arg);
+    };
+
+    fn match(const Map cases, *const any arg, *const any arg2) {
+        const let some_none = if my.hasValue "some" else "none";
+        const Option foo = cases.get(some_none);
+        const adr foo = foo.orElse([] => panic("un-handled option case"));
+        return if my.hasValue foo(my.value, arg, arg2) else foo(arg, arg2);
+    };
+
+    fn or(const A defaultValue) -> A {
+        if my.hasValue
+            return my.value
+        else
+            return defaultValue;
+    };
+
+    fn isSome() -> bool {
+        return my.hasValue;
+    };
+
+    fn toString() -> string {
+        if my.hasValue
+            return "Option: Some"
+        else
+            return "Option: None";
+    };
+};
+
+types(T)
+export fn some(const T value) {
+    return new option::<T>(true, value);
+};
+
+types(J)
+export fn none() {
+    return new option::<J>(false, NULL);
+};

--- a/rebuild-libs.sh
+++ b/rebuild-libs.sh
@@ -29,6 +29,8 @@ aflat ./libraries/std/src/Utils/Map.af ./libraries/std/Map.s
 mv ./libraries/std/Map.s ./libraries/std/Utils_Map.s
 aflat ./libraries/std/src/Utils/Option.af ./libraries/std/Option.s
 mv ./libraries/std/Option.s ./libraries/std/Utils_Option.s
+aflat ./libraries/std/src/Utils/option.af ./libraries/std/option.s
+mv ./libraries/std/option.s ./libraries/std/Utils_option.s
 aflat ./libraries/std/src/Utils/Properties.af ./libraries/std/Properties.s
 mv ./libraries/std/Properties.s ./libraries/std/Utils_Properties.s
 aflat ./libraries/std/src/Utils/Object.af ./libraries/std/Object.s

--- a/src/main.af
+++ b/src/main.af
@@ -1,6 +1,7 @@
 .needs <std>
 
 import string, {print} from "String" under str;
+import option, { some, none } from "Utils/option" under opt;
 
 types(A)
 class TestClass {
@@ -28,4 +29,7 @@ fn main() {
     print(v);
     print(test2.returnValue());
     print("Can we do it twice? Yes, we can!");
+
+    let someVal = opt.some::<int>(99);
+    print(someVal.or(0));
 };


### PR DESCRIPTION
## Summary
- introduce a templated `option` type mirroring `result`
- demonstrate usage in `src/main.af`
- rebuild library scripts to compile the new module

## Testing
- `bash rebuild-libs.sh`
- `./bin/aflat run`

------
https://chatgpt.com/codex/tasks/task_e_6852059c04a48328a88fa244918dc13e