### PR TITLE
Handle nested namespaces in Import

### DIFF
--- a/include/Parser/AST/Statements/Import.hpp
+++ b/include/Parser/AST/Statements/Import.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "Parser/AST.hpp"
+#include <unordered_map>
 
 namespace ast {
 /*
@@ -18,4 +19,7 @@ class Import : public Statement {
   gen::GenerationResult const generate(gen::CodeGenerator &generator);
   gen::GenerationResult const generateClasses(gen::CodeGenerator &generator);
 };
+void collectImportNamespaces(
+    ast::Statement *stmt,
+    std::unordered_map<std::string, std::string> &map);
 };  // namespace ast

--- a/src/Parser/AST/Statements/Import.cpp
+++ b/src/Parser/AST/Statements/Import.cpp
@@ -1,6 +1,7 @@
 #include "Parser/AST/Statements/Import.hpp"
 
 #include <fstream>
+#include <unordered_map>
 
 #include "CodeGenerator/CodeGenerator.hpp"
 #include "CodeGenerator/ScopeManager.hpp"
@@ -10,6 +11,29 @@
 #include "PreProcessor.hpp"
 
 namespace ast {
+
+static void collectImportNamespacesImpl(
+    ast::Statement *stmt,
+    std::unordered_map<std::string, std::string> &map) {
+  if (!stmt) return;
+  if (auto seq = dynamic_cast<ast::Sequence *>(stmt)) {
+    collectImportNamespacesImpl(seq->Statement1, map);
+    collectImportNamespacesImpl(seq->Statement2, map);
+  } else if (auto imp = dynamic_cast<ast::Import *>(stmt)) {
+    std::string id = imp->path;
+    if (id.find_last_of('/') != std::string::npos)
+      id = id.substr(id.find_last_of('/') + 1);
+    if (id.find_last_of('.') != std::string::npos)
+      id = id.substr(0, id.find_last_of('.'));
+    map[imp->nameSpace] = id;
+  }
+}
+
+void collectImportNamespaces(
+    ast::Statement *stmt,
+    std::unordered_map<std::string, std::string> &map) {
+  collectImportNamespacesImpl(stmt, map);
+}
 Import::Import(links::LinkedList<lex::Token *> &tokens, parse::Parser &parser) {
   this->logicalLine = tokens.peek()->lineCount;
   while (true) {
@@ -148,13 +172,18 @@ gen::GenerationResult const Import::generate(gen::CodeGenerator &generator) {
     generator.includedMemo.insert(this->path, added);
     generator.ImportsOnly(added);
   }
+  std::unordered_map<std::string, std::string> nsMap;
+  collectImportNamespaces(added, nsMap);
   for (std::string ident : this->imports) {
     if (generator.includedClasses.contains(id + "::" + ident)) continue;
     generator.includedClasses.insert(id + "::" + ident, nullptr);
     ast::Statement *statement = gen::utils::extract(ident, added, id);
-    if (statement == nullptr)
+    if (statement == nullptr) {
       generator.alert("Identifier " + ident + " not found to import");
-    OutputFile << generator.GenSTMT(statement);
+    } else {
+      statement->namespaceSwap(nsMap);
+      OutputFile << generator.GenSTMT(statement);
+    }
   }
   if (this->hasFunctions) generator.nameSpaceTable.insert(this->nameSpace, id);
   return {OutputFile, std::nullopt};
@@ -203,6 +232,9 @@ gen::GenerationResult const Import::generateClasses(
     generator.ImportsOnly(added);
   }
 
+  std::unordered_map<std::string, std::string> nsMap;
+  collectImportNamespaces(added, nsMap);
+
   for (std::string ident : this->imports) {
     ast::Statement *statement = gen::utils::extract(ident, added, id);
     if (statement == nullptr) continue;
@@ -212,6 +244,7 @@ gen::GenerationResult const Import::generateClasses(
       continue;
     if (generator.includedClasses.contains(id + "::" + ident)) continue;
     generator.includedClasses.insert(id + "::" + ident, nullptr);
+    statement->namespaceSwap(nsMap);
     OutputFile << generator.GenSTMT(statement);
   }
 

--- a/test/test_Import.cpp
+++ b/test/test_Import.cpp
@@ -6,6 +6,9 @@
 #include "PreProcessor.hpp"
 #include "Scanner.hpp"
 #include "catch.hpp"
+#include "CodeGenerator/Utils.hpp"
+#include <functional>
+#include <unordered_map>
 
 TEST_CASE("Parser handles mixed import of classes and functions", "[parser]") {
   lex::Lexer l;
@@ -52,4 +55,79 @@ TEST_CASE("ImportsOnly ignores functions in mixed import", "[codegen]") {
   REQUIRE_FALSE(gen.nameSpaceTable.contains("m"));
 
   std::remove("Temp.af");
+}
+
+TEST_CASE("Import applies nested namespaces", "[namespaces]") {
+  std::ofstream inner("Inner.af");
+  inner << "export int bar() { return 0; };\n";
+  inner.close();
+
+  std::ofstream outer("Outer.af");
+  outer << "import { bar } from \"./Inner\" under i;\n";
+  outer << "export int call() { return i.bar(); };\n";
+  outer.close();
+
+  lex::Lexer l;
+  PreProcessor pp;
+  auto code = pp.PreProcess("import {call} from \"./Outer\";", "");
+  auto tokens = l.Scan(code);
+  tokens.invert();
+  parse::Parser p;
+  ast::Statement *stmt = p.parseStmt(tokens);
+  auto *seq = dynamic_cast<ast::Sequence *>(stmt);
+  REQUIRE(seq != nullptr);
+  auto *imp = dynamic_cast<ast::Import *>(seq->Statement1);
+  REQUIRE(imp != nullptr);
+
+  test::mockGen::CodeGenerator gen("mod", p, "");
+  imp->generate(gen);
+
+  std::ifstream outerFile("Outer.af");
+  std::string outerCode((std::istreambuf_iterator<char>(outerFile)),
+                        std::istreambuf_iterator<char>());
+  outerFile.close();
+  lex::Lexer l2;
+  PreProcessor pp2;
+  auto t2 = l2.Scan(pp2.PreProcess(outerCode, ""));
+  t2.invert();
+  parse::Parser p2;
+  ast::Statement *root = p2.parseStmt(t2);
+  std::unordered_map<std::string, std::string> map;
+  ast::collectImportNamespaces(root, map);
+  std::function<ast::Statement *(ast::Statement *)> findCall = [&](ast::Statement *s) -> ast::Statement * {
+    if (!s) return nullptr;
+    if (auto f = dynamic_cast<ast::Function *>(s)) {
+      if (f->ident.ident == "call") return s;
+    }
+    if (auto seq2 = dynamic_cast<ast::Sequence *>(s)) {
+      if (auto r = findCall(seq2->Statement1)) return r;
+      return findCall(seq2->Statement2);
+    }
+    return nullptr;
+  };
+  ast::Statement *funcStmt = findCall(root);
+  REQUIRE(funcStmt != nullptr);
+  funcStmt->namespaceSwap(map);
+
+  auto *func = dynamic_cast<ast::Function *>(funcStmt);
+  REQUIRE(func != nullptr);
+  std::function<ast::Call *(ast::Statement *)> findCallNode = [&](ast::Statement *s) -> ast::Call * {
+    if (!s) return nullptr;
+    if (auto cexpr = dynamic_cast<ast::CallExpr *>(s)) return cexpr->call;
+    if (auto call = dynamic_cast<ast::Call *>(s)) return call;
+    if (auto seqn = dynamic_cast<ast::Sequence *>(s)) {
+      if (auto r = findCallNode(seqn->Statement1)) return r;
+      return findCallNode(seqn->Statement2);
+    }
+    if (auto ret = dynamic_cast<ast::Return *>(s)) return findCallNode(ret->expr);
+    if (auto expr = dynamic_cast<ast::Expr *>(s)) return findCallNode(expr->extention);
+    return nullptr;
+  };
+  auto *call = findCallNode(func->statement);
+  REQUIRE(call != nullptr);
+  REQUIRE(call->imbeddedNamespace.has_value());
+  REQUIRE(call->imbeddedNamespace.value() == "Inner");
+
+  std::remove("Inner.af");
+  std::remove("Outer.af");
 }


### PR DESCRIPTION
## Summary
- map namespaces from nested imports when loading modules
- apply mapped namespaces with `namespaceSwap`
- expose helper `collectImportNamespaces`
- test namespace swapping in nested imports

## Testing
- `cmake --build build`
- `cd bin && ./a.test`

------
https://chatgpt.com/codex/tasks/task_e_68530d72deb083289929ecda0e7f23a3