### PR TITLE
Refine vector initialization

### DIFF
--- a/libraries/std/src/Collections/vector.af
+++ b/libraries/std/src/Collections/vector.af
@@ -1,0 +1,49 @@
+.needs <std>
+
+import List from "Collections";
+import Option from "Utils/Option";
+import Result from "Utils/Result";
+import option, { some, none } from "Utils/option" under opt;
+
+// Simple templated vector backed by List
+
+types(T)
+safe dynamic class vector {
+    private List inner = new List(T);
+
+    fn init() -> Self {
+        return my;
+    };
+
+    fn pushBack(const T value) -> int {
+        inner.pushValue(value);
+        return inner.getCount();
+    };
+
+    fn popBack() -> option::<T> {
+        const Option val = inner.popBack();
+        return val.match({
+            "some": [adr ptr] => return opt.some(*ptr),
+            "none": [] => return opt.none::<T>()
+        });
+    };
+
+    fn back() -> option::<T> {
+        const Option val = inner.back();
+        return val.match({
+            "some": [adr ptr] => return opt.some(*ptr),
+            "none": [] => return opt.none::<T>()
+        });
+    };
+
+    fn get(const int index) -> option::<T> {
+        const Result res = inner.get(index);
+        return res.match({
+            "ok": [adr ptr] => return opt.some(*ptr),
+            "error": [adr err] => return opt.none::<T>()
+        });
+    };
+
+    fn getCount() -> int { return inner.getCount(); };
+};
+

--- a/rebuild-libs.sh
+++ b/rebuild-libs.sh
@@ -53,4 +53,5 @@ aflat ./libraries/std/src/JSON/Property.af ./libraries/std/JSON_Property.s
 aflat ./libraries/std/src/Collections/Iterator.af ./libraries/std/Iterator.s
 aflat ./libraries/std/src/Collections/Scroller.af ./libraries/std/Scroller.s
 aflat ./libraries/std/src/Collections/Enumerator.af ./libraries/std/Enumerator.s
+aflat ./libraries/std/src/Collections/vector.af ./libraries/std/vector.s
 gcc -g -no-pie -S -o ./libraries/std/request.s ./libraries/std/src/request.c

--- a/src/main.af
+++ b/src/main.af
@@ -2,6 +2,7 @@
 
 import string, {print} from "String" under str;
 import option, { some, none } from "Utils/option" under opt;
+import vector from "Collections/vector";
 
 types(A)
 class TestClass {
@@ -32,4 +33,9 @@ fn main() {
 
     let someVal = opt.some::<int>(99);
     print(someVal.or(0));
+
+    let numbers = new vector::<int>();
+    numbers.pushBack(1);
+    numbers.pushBack(2);
+    print(numbers.get(0).or(0));
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -577,6 +577,7 @@ bool runConfig(cfg::Config &config, const std::string &libPath, char pmode) {
                                    "JSON_Property.s",
                                    "Iterator.s",
                                    "Enumerator.s",
+                                   "vector.s",
                                    "Scroller.s",
                                    "Utils_Defer.s",
                                    "Memory.s",


### PR DESCRIPTION
## Summary
- initialize `vector`'s internal list at the field declaration
- simplify the constructor

## Testing
- `bash ./rebuild-libs.sh` *(fails: ./bin/aflat not found)*
- `make` *(interrupted during heavy compilation)*
- `./bin/aflat run` *(fails: No such file or directory)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68532088299083289d36461808dc3031