### PR TITLE
Add trace option for CodeGenerator alerts

### DIFF
--- a/include/CLI.hpp
+++ b/include/CLI.hpp
@@ -5,6 +5,7 @@
 
 struct CommandLineOptions {
   bool debug = false;
+  bool traceAlerts = false;
   std::string outputFile = "out.s";
   std::string configFile = "aflat.cfg";
   std::string command;

--- a/include/CodeGenerator/CodeGenerator.hpp
+++ b/include/CodeGenerator/CodeGenerator.hpp
@@ -117,7 +117,9 @@ class CodeGenerator {
   links::LinkedList<gen::Symbol> GenTable(
       ast::Statement *STMT, links::LinkedList<gen::Symbol> &table);
   // a function for warnings or errors
-  void alert(std::string message, bool error = true);
+  void alert(std::string message, bool error = true,
+             const char *file = nullptr, int line = 0);
+  static void enableAlertTrace(bool enable);
   gen::Type **instantiateGenericClass(ast::Class *cls,
                                       const std::vector<std::string> &types,
                                       std::string &newName,
@@ -126,6 +128,9 @@ class CodeGenerator {
                 const std::string &source = "");
   asmc::File *deScope(gen::Symbol &sym);
   bool hasError() const { return errorFlag; }
+
+ private:
+  static bool traceAlert;
 };
 }  // namespace gen
 

--- a/include/CodeGenerator/CodeGenerator.hpp
+++ b/include/CodeGenerator/CodeGenerator.hpp
@@ -117,8 +117,8 @@ class CodeGenerator {
   links::LinkedList<gen::Symbol> GenTable(
       ast::Statement *STMT, links::LinkedList<gen::Symbol> &table);
   // a function for warnings or errors
-  void alert(std::string message, bool error = true,
-             const char *file = nullptr, int line = 0);
+  void alert(std::string message, bool error = true, const char *file = nullptr,
+             int line = 0);
   static void enableAlertTrace(bool enable);
   gen::Type **instantiateGenericClass(ast::Class *cls,
                                       const std::vector<std::string> &types,

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -8,11 +8,12 @@ bool parseCommandLine(int argc, char **argv, CommandLineOptions &opts) {
   static option longOptions[] = {{"help", no_argument, nullptr, 'h'},
                                  {"output", required_argument, nullptr, 'o'},
                                  {"debug", no_argument, nullptr, 'd'},
+                                 {"trace-alerts", no_argument, nullptr, 't'},
                                  {"config", required_argument, nullptr, 'c'},
                                  {nullptr, 0, nullptr, 0}};
 
   int opt;
-  while ((opt = getopt_long(argc, argv, "hdo:c:", longOptions, nullptr)) !=
+  while ((opt = getopt_long(argc, argv, "hdo:tc:", longOptions, nullptr)) !=
          -1) {
     switch (opt) {
       case 'o':
@@ -20,6 +21,9 @@ bool parseCommandLine(int argc, char **argv, CommandLineOptions &opts) {
         break;
       case 'd':
         opts.debug = true;
+        break;
+      case 't':
+        opts.traceAlerts = true;
         break;
       case 'c':
         opts.configFile = optarg;
@@ -61,5 +65,6 @@ void printUsage(const char *prog) {
       << "  -o, --output <file> Output file when compiling a single file\n"
       << "  -c, --config <file> Use alternative config file\n"
       << "  -d, --debug         Enable debug information\n"
+      << "  -t, --trace-alerts  Trace CodeGenerator alerts\n"
       << "  -h, --help          Display this help message\n";
 }

--- a/src/CodeGenerator/CodeGenerator.cpp
+++ b/src/CodeGenerator/CodeGenerator.cpp
@@ -1,7 +1,6 @@
 #include "CodeGenerator/CodeGenerator.hpp"
 
 #include <execinfo.h>
-
 #include <unistd.h>
 
 #include <boost/uuid/random_generator.hpp>
@@ -203,7 +202,8 @@ bool gen::CodeGenerator::canAssign(ast::Type type, std::string typeName,
   };
 
   alert(format("Type mismatch on line {}: " + fmt, this->logicalLine,
-               type.typeName, typeName), true, __FILE__, __LINE__);
+               type.typeName, typeName),
+        true, __FILE__, __LINE__);
   return false;
 }
 
@@ -228,9 +228,9 @@ gen::Type **gen::CodeGenerator::getType(std::string typeName,
     // find . in the type name
     if (typeName.find('.') == std::string::npos)
       this->alert("Type " + typeName +
-                  " not found in type list, did you forget to "
-                  "include the file that defines it?", true, __FILE__,
-                  __LINE__);
+                      " not found in type list, did you forget to "
+                      "include the file that defines it?",
+                  true, __FILE__, __LINE__);
 
     auto typeNameParts = splitTypeName(typeName);
     auto typeNamePart = typeNameParts.front();
@@ -240,16 +240,16 @@ gen::Type **gen::CodeGenerator::getType(std::string typeName,
 
     if (cl == nullptr) {
       this->alert("Type " + typeName +
-                  " not found in type list, did you forget to "
-                  "include the file that defines it?", true, __FILE__,
-                  __LINE__);
+                      " not found in type list, did you forget to "
+                      "include the file that defines it?",
+                  true, __FILE__, __LINE__);
     }
 
     if (cl->genericTypes.size() != typeNameParts.size() - 1) {
       this->alert("Type " + typeName +
-                  " not found in type list, did you forget to "
-                  "include the file that defines it?", true, __FILE__,
-                  __LINE__);
+                      " not found in type list, did you forget to "
+                      "include the file that defines it?",
+                  true, __FILE__, __LINE__);
     }
     // typeNameParts without the first parts
     auto typeNameWithoutFirstPart = typeNameParts;

--- a/src/CodeGenerator/CodeGenerator.cpp
+++ b/src/CodeGenerator/CodeGenerator.cpp
@@ -1,5 +1,7 @@
 #include "CodeGenerator/CodeGenerator.hpp"
 
+#include <execinfo.h>
+
 #include <unistd.h>
 
 #include <boost/uuid/random_generator.hpp>
@@ -21,7 +23,20 @@
 
 using namespace gen::utils;
 
-void gen::CodeGenerator::alert(std::string message, bool error) {
+bool gen::CodeGenerator::traceAlert = false;
+
+void gen::CodeGenerator::enableAlertTrace(bool enable) { traceAlert = enable; }
+
+void gen::CodeGenerator::alert(std::string message, bool error,
+                               const char *file, int line) {
+  if (traceAlert && file) {
+    std::cerr << "[CG alert] " << file << ":" << line << std::endl;
+    void *array[10];
+    int size = backtrace(array, 10);
+    char **symbols = backtrace_symbols(array, size);
+    for (int i = 0; i < size; ++i) std::cerr << symbols[i] << std::endl;
+    free(symbols);
+  }
   if (error) {
     this->errorFlag = true;
     std::string context;
@@ -90,7 +105,8 @@ bool gen::CodeGenerator::canAssign(ast::Type type, std::string typeName,
   if (typeName == "NULLTYPE" && type.typeName == "void") return true;
   if (typeName == "generic" && type.typeName == "NULLTYPE") return true;
   if (typeName == "NULLTYPE" && type.typeName == "generic") return true;
-  if (typeName == "void") this->alert("cannot use void function as value");
+  if (typeName == "void")
+    this->alert("cannot use void function as value", true, __FILE__, __LINE__);
   if (typeName == "--std--flex--function" || typeName == "any" ||
       type.typeName == "any")
     return true;
@@ -187,7 +203,7 @@ bool gen::CodeGenerator::canAssign(ast::Type type, std::string typeName,
   };
 
   alert(format("Type mismatch on line {}: " + fmt, this->logicalLine,
-               type.typeName, typeName));
+               type.typeName, typeName), true, __FILE__, __LINE__);
   return false;
 }
 
@@ -213,7 +229,8 @@ gen::Type **gen::CodeGenerator::getType(std::string typeName,
     if (typeName.find('.') == std::string::npos)
       this->alert("Type " + typeName +
                   " not found in type list, did you forget to "
-                  "include the file that defines it?");
+                  "include the file that defines it?", true, __FILE__,
+                  __LINE__);
 
     auto typeNameParts = splitTypeName(typeName);
     auto typeNamePart = typeNameParts.front();
@@ -224,13 +241,15 @@ gen::Type **gen::CodeGenerator::getType(std::string typeName,
     if (cl == nullptr) {
       this->alert("Type " + typeName +
                   " not found in type list, did you forget to "
-                  "include the file that defines it?");
+                  "include the file that defines it?", true, __FILE__,
+                  __LINE__);
     }
 
     if (cl->genericTypes.size() != typeNameParts.size() - 1) {
       this->alert("Type " + typeName +
                   " not found in type list, did you forget to "
-                  "include the file that defines it?");
+                  "include the file that defines it?", true, __FILE__,
+                  __LINE__);
     }
     // typeNameParts without the first parts
     auto typeNameWithoutFirstPart = typeNameParts;

--- a/src/CodeGenerator/ExprImply.cpp
+++ b/src/CodeGenerator/ExprImply.cpp
@@ -41,7 +41,7 @@ ast::Expr *gen::CodeGenerator::imply(ast::Expr *expr, std::string typeName) {
   }
   this->alert("Cannot imply type " + typeName +
               " from expression of type at line " +
-              std::to_string(expr->logicalLine));
+              std::to_string(expr->logicalLine), true, __FILE__, __LINE__);
   return nullptr;
 }
 }  // namespace gen

--- a/src/CodeGenerator/ExprImply.cpp
+++ b/src/CodeGenerator/ExprImply.cpp
@@ -40,8 +40,9 @@ ast::Expr *gen::CodeGenerator::imply(ast::Expr *expr, std::string typeName) {
     }
   }
   this->alert("Cannot imply type " + typeName +
-              " from expression of type at line " +
-              std::to_string(expr->logicalLine), true, __FILE__, __LINE__);
+                  " from expression of type at line " +
+                  std::to_string(expr->logicalLine),
+              true, __FILE__, __LINE__);
   return nullptr;
 }
 }  // namespace gen

--- a/src/CodeGenerator/GenExpr.cpp
+++ b/src/CodeGenerator/GenExpr.cpp
@@ -54,7 +54,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
         call->ident = new_class_name;
         if (t == nullptr) {
           alert("Something went wrong with the generic class " + call->ident +
-                " in " + this->moduleId, true, __FILE__, __LINE__);
+                    " in " + this->moduleId,
+                true, __FILE__, __LINE__);
         }
       }
     }
@@ -138,7 +139,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
           output.type != "generic")
         this->alert(
             "Can only explicitly cast to a type from any, adr, "
-            "or generic", true, __FILE__, __LINE__);
+            "or generic",
+            true, __FILE__, __LINE__);
       output.type = exprCall->typeCast;
     }
   } else if (dynamic_cast<ast::Var *>(expr) != nullptr) {
@@ -334,8 +336,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
       gen::Symbol sym = std::get<1>(resolved);
       if (sym.sold != -1) {
         alert("variable " + var.Ident + " was sold on line " +
-              std::to_string(sym.sold) + " and cannot be used", true,
-              __FILE__, __LINE__);
+                  std::to_string(sym.sold) + " and cannot be used",
+              true, __FILE__, __LINE__);
       }
 
       if (sym.type.isReference && !var.clean) {
@@ -401,7 +403,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
           output.type != "generic")
         this->alert(
             "Can only explicitly cast to a type from any, adr, "
-            "or generic", true, __FILE__, __LINE__);
+            "or generic",
+            true, __FILE__, __LINE__);
       output.type = var.typeCast;
     }
   } else if (dynamic_cast<ast::Buy *>(expr) != nullptr) {
@@ -521,7 +524,7 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
       pos = strLit->val.find("%%%", 0);
       if (pos == std::string::npos)
         this->alert("too many arguments for format string", true, __FILE__,
-                     __LINE__);
+                    __LINE__);
 
       asmc::File file;
 
@@ -535,15 +538,15 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
             if (cl->parent != nullptr) {
               if (cl->parent->nameTable["toString"] == nullptr) {
                 this->alert("class " + cl->Ident +
-                            " does not contain a toString method", true,
-                            __FILE__, __LINE__);
+                                " does not contain a toString method",
+                            true, __FILE__, __LINE__);
               } else {
                 cl = cl->parent;
               }
             } else {
-              this->alert("class " + cl->Ident +
-                          " does not contain a toString method", true,
-                          __FILE__, __LINE__);
+              this->alert(
+                  "class " + cl->Ident + " does not contain a toString method",
+                  true, __FILE__, __LINE__);
             }
           }
 
@@ -571,7 +574,7 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
         strLit->val.replace(pos, 3, "%c");
       else {
         this->alert("unable to format type of " + exp.type, true, __FILE__,
-                     __LINE__);
+                    __LINE__);
       }
 
       list->args << expr;
@@ -1100,7 +1103,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
           output.type != "generic")
         this->alert(
             "Can only explicitly cast to a type from any, adr, "
-            "or generic", true, __FILE__, __LINE__);
+            "or generic",
+            true, __FILE__, __LINE__);
       output.type = comp.typeCast;
     }
   } else if (dynamic_cast<ast::Lambda *>(expr) != nullptr) {
@@ -1176,7 +1180,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
     if (malloc == nullptr)
       alert(
           "Please import std library in order to use new operator.\n\n -> "
-          ".needs <std> \n\n", true, __FILE__, __LINE__);
+          ".needs <std> \n\n",
+          true, __FILE__, __LINE__);
     gen::Type **type = this->typeList[newExpr.type.typeName];
     if (type == nullptr) {
       auto cls = this->genericTypes[newExpr.type.typeName];
@@ -1194,8 +1199,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
     auto cl = dynamic_cast<gen::Class *>(*type);
     if (cl == nullptr)
       alert("The new operator can only be used with classes. Type " +
-            newExpr.type.typeName + " is not a class", true, __FILE__,
-            __LINE__);
+                newExpr.type.typeName + " is not a class",
+            true, __FILE__, __LINE__);
     // check if the class has a constructor
     ast::Function *init = cl->nameTable["init"];
 

--- a/src/CodeGenerator/GenExpr.cpp
+++ b/src/CodeGenerator/GenExpr.cpp
@@ -54,7 +54,7 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
         call->ident = new_class_name;
         if (t == nullptr) {
           alert("Something went wrong with the generic class " + call->ident +
-                " in " + this->moduleId);
+                " in " + this->moduleId, true, __FILE__, __LINE__);
         }
       }
     }
@@ -67,7 +67,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
       gen::Class *cl = dynamic_cast<gen::Class *>(*t);
       if (cl != nullptr) {
         if (cl->dynamic)
-          alert("Dynamic class '" + cl->Ident + "' must be called with new");
+          alert("Dynamic class '" + cl->Ident + "' must be called with new",
+                true, __FILE__, __LINE__);
         // allocate space for the object
         ast::Type type = ast::Type();
         type.typeName = cl->Ident;
@@ -117,7 +118,7 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
           output.type = cl->Ident;
         }
       } else {
-        alert("Class " + call->ident + " not found");
+        alert("Class " + call->ident + " not found", true, __FILE__, __LINE__);
       }
     } else {
       auto callGen = call->generate(*this);
@@ -137,7 +138,7 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
           output.type != "generic")
         this->alert(
             "Can only explicitly cast to a type from any, adr, "
-            "or generic");
+            "or generic", true, __FILE__, __LINE__);
       output.type = exprCall->typeCast;
     }
   } else if (dynamic_cast<ast::Var *>(expr) != nullptr) {
@@ -156,7 +157,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
       if (this->nameSpaceTable.contains(var.Ident)) {
         nsp = this->nameSpaceTable.get(ident) + ".";
         if (var.modList.trail() == 0)
-          alert("NameSpace " + ident + " cannot be used as a variable");
+          alert("NameSpace " + ident + " cannot be used as a variable", true,
+                __FILE__, __LINE__);
         ident = nsp + var.modList.shift();
       };
 
@@ -167,12 +169,14 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
         Enum *en = dynamic_cast<Enum *>(type);
         if (en) {
           if (var.modList.trail() == 0) {
-            alert("Enum " + ident + " cannot be used as a variable");
+            alert("Enum " + ident + " cannot be used as a variable", true,
+                  __FILE__, __LINE__);
           }
           std::string enumIdent = var.modList.shift();
           Enum::EnumValue *item = en->values[enumIdent];
           if (!item) {
-            alert("Enum " + ident + " does not contain " + enumIdent);
+            alert("Enum " + ident + " does not contain " + enumIdent, true,
+                  __FILE__, __LINE__);
           }
           output.access = '$' + std::to_string(item->value);
           output.type = en->Ident;
@@ -187,7 +191,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
               output.type = "adr";
               output.size = asmc::QWord;
             } else {
-              alert("Class " + ident + " does not contain " + functionName);
+              alert("Class " + ident + " does not contain " + functionName,
+                    true, __FILE__, __LINE__);
             }
           } else {
             output.access =
@@ -321,7 +326,7 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
         strLit->logicalLine = this->logicalLine;
         output = this->GenExpr(strLit, OutputFile);
       } else {
-        alert("variable not found " + ident);
+        alert("variable not found " + ident, true, __FILE__, __LINE__);
       }
       var.modList.invert();
       var.modList.reset();
@@ -329,7 +334,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
       gen::Symbol sym = std::get<1>(resolved);
       if (sym.sold != -1) {
         alert("variable " + var.Ident + " was sold on line " +
-              std::to_string(sym.sold) + " and cannot be used");
+              std::to_string(sym.sold) + " and cannot be used", true,
+              __FILE__, __LINE__);
       }
 
       if (sym.type.isReference && !var.clean) {
@@ -395,7 +401,7 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
           output.type != "generic")
         this->alert(
             "Can only explicitly cast to a type from any, adr, "
-            "or generic");
+            "or generic", true, __FILE__, __LINE__);
       output.type = var.typeCast;
     }
   } else if (dynamic_cast<ast::Buy *>(expr) != nullptr) {
@@ -403,7 +409,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
     // for now, we will onlt support buying of a variable (lvalue)
     auto var = dynamic_cast<ast::Var *>(buy->expr);
     if (var == nullptr) {
-      this->alert("buying of non-variable not supported");
+      this->alert("buying of non-variable not supported", true, __FILE__,
+                  __LINE__);
     }
 
     auto resolved =
@@ -411,7 +418,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
                             links::LinkedList<ast::Expr *>(), false);
 
     if (std::get<2>(resolved) == false) {
-      this->alert("attemptted to buy an undeclared variable: " + var->Ident);
+      this->alert("attemptted to buy an undeclared variable: " + var->Ident,
+                  true, __FILE__, __LINE__);
     }
 
     gen::Symbol *sym = &std::get<1>(resolved);
@@ -460,7 +468,7 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
     if (std::get<2>(resolved)) {
       lea->from = std::get<0>(resolved);
     } else
-      alert("variable not found " + ref.Ident);
+      alert("variable not found " + ref.Ident, true, __FILE__, __LINE__);
     lea->to = this->registers["%rax"]->get(asmc::QWord);
 
     output.access = registers["%rax"]->get(asmc::QWord);
@@ -512,7 +520,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
     for (auto expr : str.args) {
       pos = strLit->val.find("%%%", 0);
       if (pos == std::string::npos)
-        this->alert("too many arguments for format string");
+        this->alert("too many arguments for format string", true, __FILE__,
+                     __LINE__);
 
       asmc::File file;
 
@@ -526,13 +535,15 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
             if (cl->parent != nullptr) {
               if (cl->parent->nameTable["toString"] == nullptr) {
                 this->alert("class " + cl->Ident +
-                            " does not contain a toString method");
+                            " does not contain a toString method", true,
+                            __FILE__, __LINE__);
               } else {
                 cl = cl->parent;
               }
             } else {
               this->alert("class " + cl->Ident +
-                          " does not contain a toString method");
+                          " does not contain a toString method", true,
+                          __FILE__, __LINE__);
             }
           }
 
@@ -559,7 +570,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
       else if (exp.type == "char")
         strLit->val.replace(pos, 3, "%c");
       else {
-        this->alert("unable to format type of " + exp.type);
+        this->alert("unable to format type of " + exp.type, true, __FILE__,
+                     __LINE__);
       }
 
       list->args << expr;
@@ -608,7 +620,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
                             links::LinkedList<ast::Expr *>(), false);
 
     if (!std::get<2>(resolved)) {
-      alert("variable not found to deRef" + deRef.Ident);
+      alert("variable not found to deRef" + deRef.Ident, true, __FILE__,
+            __LINE__);
     }
 
     gen::Symbol *sym = &std::get<1>(resolved);
@@ -1067,7 +1080,7 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
           break;
         }
         default: {
-          alert("Unhandled operator in comparison");
+          alert("Unhandled operator in comparison", true, __FILE__, __LINE__);
           break;
         }
       }
@@ -1087,7 +1100,7 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
           output.type != "generic")
         this->alert(
             "Can only explicitly cast to a type from any, adr, "
-            "or generic");
+            "or generic", true, __FILE__, __LINE__);
       output.type = comp.typeCast;
     }
   } else if (dynamic_cast<ast::Lambda *>(expr) != nullptr) {
@@ -1163,7 +1176,7 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
     if (malloc == nullptr)
       alert(
           "Please import std library in order to use new operator.\n\n -> "
-          ".needs <std> \n\n");
+          ".needs <std> \n\n", true, __FILE__, __LINE__);
     gen::Type **type = this->typeList[newExpr.type.typeName];
     if (type == nullptr) {
       auto cls = this->genericTypes[newExpr.type.typeName];
@@ -1174,12 +1187,15 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
         newExpr.type.typeName = new_class_name;
       }
     }
-    if (type == nullptr) alert("Type " + newExpr.type.typeName + " not found");
+    if (type == nullptr)
+      alert("Type " + newExpr.type.typeName + " not found", true, __FILE__,
+            __LINE__);
     // check if the function is a class
     auto cl = dynamic_cast<gen::Class *>(*type);
     if (cl == nullptr)
       alert("The new operator can only be used with classes. Type " +
-            newExpr.type.typeName + " is not a class");
+            newExpr.type.typeName + " is not a class", true, __FILE__,
+            __LINE__);
     // check if the class has a constructor
     ast::Function *init = cl->nameTable["init"];
 
@@ -1370,7 +1386,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
 
     OutputFile.text << label1;
     if (!ifExpr->falseExpr)
-      this->alert("if expression must have a false branch");
+      this->alert("if expression must have a false branch", true, __FILE__,
+                  __LINE__);
     gen::Expr falseExpr = this->GenExpr(ifExpr->falseExpr, OutputFile);
     asmc::Mov *mov3 = new asmc::Mov();
     mov3->logicalLine = this->logicalLine;
@@ -1391,7 +1408,7 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
     output.size = trueExpr.size;
     output.type = trueExpr.type;
   } else {
-    this->alert("Unhandled expression");
+    this->alert("Unhandled expression", true, __FILE__, __LINE__);
   }
 
   if (expr->extention != nullptr) {
@@ -1425,7 +1442,8 @@ gen::Expr gen::CodeGenerator::GenExpr(ast::Expr *expr, asmc::File &OutputFile,
       var->modList.invert();
       var->Ident = tempName;
     } else {
-      this->alert("Cannot extend an expression of this type");
+      this->alert("Cannot extend an expression of this type", true, __FILE__,
+                  __LINE__);
     }
 
     output = this->GenExpr(expr->extention, OutputFile, size);

--- a/src/CodeGenerator/Resolver.cpp
+++ b/src/CodeGenerator/Resolver.cpp
@@ -15,7 +15,8 @@ Type **CodeGenerator::instantiateGenericClass(
   if (types.size() != classStatement->genericTypes.size())
     alert("Generic class " + cls->ident.ident + " requires " +
           std::to_string(classStatement->genericTypes.size()) +
-          " template types, but got " + std::to_string(types.size()));
+          " template types, but got " + std::to_string(types.size()), true,
+          __FILE__, __LINE__);
   for (size_t i = 0; i < types.size(); i++) {
     newName += "." + types[i];
     genericMap[classStatement->genericTypes[i]] = types[i];
@@ -55,7 +56,8 @@ CodeGenerator::resolveSymbol(std::string ident,
   if (this->nameSpaceTable.contains(ident)) {
     nsp = this->nameSpaceTable.get(ident) + ".";
     if (modList.count == 0)
-      alert("NameSpace " + ident + " cannot be used as a variable");
+      alert("NameSpace " + ident + " cannot be used as a variable", true,
+            __FILE__, __LINE__);
     ident = nsp + modList.shift();
   };
 
@@ -93,7 +95,8 @@ CodeGenerator::resolveSymbol(std::string ident,
                                                         modList.shift());
       };
       if (modSym == nullptr)
-        alert("variable not found " + last.typeName + "." + sto);
+        alert("variable not found " + last.typeName + "." + sto, true, __FILE__,
+              __LINE__);
       last = modSym->type;
       int tbyte = modSym->byteMod;
       asmc::Mov *mov = new asmc::Mov();
@@ -124,7 +127,7 @@ CodeGenerator::resolveSymbol(std::string ident,
                     "the given type {} is not subscriptable");
 
     if (modSym->type.indices.trail() != indicies.trail())
-      alert("invalid index count");
+      alert("invalid index count", true, __FILE__, __LINE__);
 
     int multiplier = sizeToInt(modSym->type.typeHint->size);
 

--- a/src/CodeGenerator/Resolver.cpp
+++ b/src/CodeGenerator/Resolver.cpp
@@ -14,9 +14,9 @@ Type **CodeGenerator::instantiateGenericClass(
   newName = classStatement->ident.ident;
   if (types.size() != classStatement->genericTypes.size())
     alert("Generic class " + cls->ident.ident + " requires " +
-          std::to_string(classStatement->genericTypes.size()) +
-          " template types, but got " + std::to_string(types.size()), true,
-          __FILE__, __LINE__);
+              std::to_string(classStatement->genericTypes.size()) +
+              " template types, but got " + std::to_string(types.size()),
+          true, __FILE__, __LINE__);
   for (size_t i = 0; i < types.size(); i++) {
     newName += "." + types[i];
     genericMap[classStatement->genericTypes[i]] = types[i];

--- a/src/CodeGenerator/ScopeManage.cpp
+++ b/src/CodeGenerator/ScopeManage.cpp
@@ -97,13 +97,13 @@ void ScopeManager::popScope(CodeGenerator *callback, asmc::File &OutputFile,
                               "\" is assigned but never "
                               "used please consider removing it. If this is a "
                               "placeholder var prefix with `__`",
-                          false);
+                          false, __FILE__, __LINE__);
         };
         if (sym.assignCount < 1 && sym.mutable_) {
           callback->alert("Symbol \"" + sym.symbol +
                               "\" is mutable but never "
                               "assigned please consider making it immutable.",
-                          false);
+                          false, __FILE__, __LINE__);
         };
       }
       if (!fPop) {

--- a/src/CodeGenerator/Statements.cpp
+++ b/src/CodeGenerator/Statements.cpp
@@ -30,7 +30,7 @@ links::LinkedList<gen::Symbol> gen::CodeGenerator::GenTable(
     int offset = gen::utils::sizeToInt(arg->type.size);
 
     if (table.search<std::string>(searchSymbol, arg->ident) != nullptr)
-      alert("redefined variable:" + arg->ident);
+      alert("redefined variable:" + arg->ident, true, __FILE__, __LINE__);
 
     symbol.symbol = arg->ident;
     if (table.head == nullptr) {
@@ -53,7 +53,7 @@ links::LinkedList<gen::Symbol> gen::CodeGenerator::GenTable(
 
     if (this->SymbolTable.search<std::string>(searchSymbol, dec->ident) !=
         nullptr)
-      alert("redefined variable" + dec->ident);
+      alert("redefined variable" + dec->ident, true, __FILE__, __LINE__);
 
     gen::Symbol Symbol;
     if (this->SymbolTable.head == nullptr) {
@@ -86,7 +86,7 @@ asmc::File gen::CodeGenerator::GenArgs(ast::Statement *STMT,
     if (intArgsCounter > 6) {
       alert(
           "AFlat compiler cannot handle more than 6 int / pointer "
-          "arguments.");
+          "arguments.", true, __FILE__, __LINE__);
     } else {
       asmc::Size size;
       gen::Symbol symbol;
@@ -121,7 +121,7 @@ asmc::File gen::CodeGenerator::GenArgs(ast::Statement *STMT,
         } else {
           alert("The symbol " + arg->requestType +
                 " is not defined in the current scope so its type cannot be "
-                "resolved");
+                "resolved", true, __FILE__, __LINE__);
         }
       }
 

--- a/src/CodeGenerator/Statements.cpp
+++ b/src/CodeGenerator/Statements.cpp
@@ -86,7 +86,8 @@ asmc::File gen::CodeGenerator::GenArgs(ast::Statement *STMT,
     if (intArgsCounter > 6) {
       alert(
           "AFlat compiler cannot handle more than 6 int / pointer "
-          "arguments.", true, __FILE__, __LINE__);
+          "arguments.",
+          true, __FILE__, __LINE__);
     } else {
       asmc::Size size;
       gen::Symbol symbol;
@@ -119,9 +120,11 @@ asmc::File gen::CodeGenerator::GenArgs(ast::Statement *STMT,
           this->typeList.push(cl);
           arg->type = ast::Type(cl->Ident, asmc::QWord);
         } else {
-          alert("The symbol " + arg->requestType +
-                " is not defined in the current scope so its type cannot be "
-                "resolved", true, __FILE__, __LINE__);
+          alert(
+              "The symbol " + arg->requestType +
+                  " is not defined in the current scope so its type cannot be "
+                  "resolved",
+              true, __FILE__, __LINE__);
         }
       }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,6 +37,7 @@ int main(int argc, char *argv[]) {
   if (!parseCommandLine(argc, argv, cli)) {
     return 1;
   }
+  gen::CodeGenerator::enableAlertTrace(cli.traceAlerts);
 
   std::string filename = getExePath();
   std::string exepath = filename.substr(0, filename.find_last_of("/"));

--- a/test/test_CLI.cpp
+++ b/test/test_CLI.cpp
@@ -2,10 +2,11 @@
 #include "catch.hpp"
 
 TEST_CASE("CLI parses flags", "[cli]") {
-  const char *argv[] = {"aflat", "-d", "-o", "foo.s", "build"};
+  const char *argv[] = {"aflat", "-d", "-t", "-o", "foo.s", "build"};
   CommandLineOptions opts;
-  REQUIRE(parseCommandLine(5, (char **)argv, opts));
+  REQUIRE(parseCommandLine(6, (char **)argv, opts));
   REQUIRE(opts.debug == true);
+  REQUIRE(opts.traceAlerts == true);
   REQUIRE(opts.outputFile == "foo.s");
   REQUIRE(opts.command == "build");
 }


### PR DESCRIPTION
## Summary
- make CodeGenerator alert emit call site info and backtrace when enabled
- allow enabling alert tracing via `--trace-alerts` CLI option
- expose new flag in CommandLineOptions and add CLI test

## Testing
- `make`
- `cmake --build build` *(failed: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68541b8aef38832880c7e55d17fcb610