### PR TITLE
Add compile progress logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,12 @@ file(GLOB_RECURSE testing_Modules
     src/*.cpp
 )
 
-list(REMOVE_ITEM testing_Modules ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
+# Do not remove main.cpp when building tests so helper functions are available
+# The main function is excluded via the AFLAT_TEST define.
 
 message (STATUS ${testing_Modules})
 add_executable(a.test ${testing_Modules})
 target_include_directories(a.test PRIVATE include/)
 target_link_libraries(a.test PRIVATE Catch2::Catch2WithMain)
+target_compile_definitions(a.test PRIVATE AFLAT_TEST)
 # target_link_options(test PRIVATE -flto)

--- a/include/CLI.hpp
+++ b/include/CLI.hpp
@@ -7,7 +7,7 @@ struct CommandLineOptions {
   bool debug = false;
   bool traceAlerts = false;
   bool quiet = false;
-  std::string outputFile = "out.s";
+  std::string outputFile;  // set via -o when compiling single files
   std::string configFile = "aflat.cfg";
   std::string command;
   std::vector<std::string> args;

--- a/include/CLI.hpp
+++ b/include/CLI.hpp
@@ -6,6 +6,7 @@
 struct CommandLineOptions {
   bool debug = false;
   bool traceAlerts = false;
+  bool quiet = false;
   std::string outputFile = "out.s";
   std::string configFile = "aflat.cfg";
   std::string command;

--- a/include/Progress.hpp
+++ b/include/Progress.hpp
@@ -1,0 +1,19 @@
+#ifndef AFLAT_PROGRESS_HPP
+#define AFLAT_PROGRESS_HPP
+
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+class CompileProgress {
+ public:
+  explicit CompileProgress(const std::vector<std::string>& sources);
+  void update(const std::string& src, const std::string& state);
+
+ private:
+  std::vector<std::string> sources_;
+  std::unordered_map<std::string, size_t> index_;
+};
+
+#endif // AFLAT_PROGRESS_HPP

--- a/include/Progress.hpp
+++ b/include/Progress.hpp
@@ -8,12 +8,14 @@
 
 class CompileProgress {
  public:
-  explicit CompileProgress(const std::vector<std::string>& sources);
+  explicit CompileProgress(const std::vector<std::string>& sources,
+                           bool quiet = false);
   void update(const std::string& src, const std::string& state);
 
  private:
   std::vector<std::string> sources_;
   std::unordered_map<std::string, size_t> index_;
+  bool quiet_ = false;
 };
 
 #endif // AFLAT_PROGRESS_HPP

--- a/include/Progress.hpp
+++ b/include/Progress.hpp
@@ -18,4 +18,4 @@ class CompileProgress {
   bool quiet_ = false;
 };
 
-#endif // AFLAT_PROGRESS_HPP
+#endif  // AFLAT_PROGRESS_HPP

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 
 bool parseCommandLine(int argc, char **argv, CommandLineOptions &opts) {
+  optind = 1;  // reset getopt state for repeated calls
   static option longOptions[] = {{"help", no_argument, nullptr, 'h'},
                                  {"output", required_argument, nullptr, 'o'},
                                  {"debug", no_argument, nullptr, 'd'},

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -8,12 +8,13 @@ bool parseCommandLine(int argc, char **argv, CommandLineOptions &opts) {
   static option longOptions[] = {{"help", no_argument, nullptr, 'h'},
                                  {"output", required_argument, nullptr, 'o'},
                                  {"debug", no_argument, nullptr, 'd'},
+                                 {"quiet", no_argument, nullptr, 'q'},
                                  {"trace-alerts", no_argument, nullptr, 't'},
                                  {"config", required_argument, nullptr, 'c'},
                                  {nullptr, 0, nullptr, 0}};
 
   int opt;
-  while ((opt = getopt_long(argc, argv, "hdo:tc:", longOptions, nullptr)) !=
+  while ((opt = getopt_long(argc, argv, "hdo:tc:q", longOptions, nullptr)) !=
          -1) {
     switch (opt) {
       case 'o':
@@ -21,6 +22,9 @@ bool parseCommandLine(int argc, char **argv, CommandLineOptions &opts) {
         break;
       case 'd':
         opts.debug = true;
+        break;
+      case 'q':
+        opts.quiet = true;
         break;
       case 't':
         opts.traceAlerts = true;
@@ -66,6 +70,7 @@ void printUsage(const char *prog) {
       << "  -o, --output <file> Output file when compiling a single file\n"
       << "  -c, --config <file> Use alternative config file\n"
       << "  -d, --debug         Enable debug information\n"
+      << "  -q, --quiet         Suppress build progress output\n"
       << "  -t, --trace-alerts  Trace CodeGenerator alerts\n"
       << "  -h, --help          Display this help message\n";
 }

--- a/src/Progress.cpp
+++ b/src/Progress.cpp
@@ -1,0 +1,22 @@
+#include "Progress.hpp"
+
+CompileProgress::CompileProgress(const std::vector<std::string>& sources) {
+  sources_ = sources;
+  for (size_t i = 0; i < sources.size(); ++i) {
+    index_[sources[i]] = i;
+    std::cout << "[waiting] " << sources[i] << std::endl;
+  }
+  std::cout.flush();
+}
+
+void CompileProgress::update(const std::string& src, const std::string& state) {
+  auto it = index_.find(src);
+  if (it == index_.end()) return;
+  size_t line = it->second;
+  size_t linesUp = sources_.size() - line;
+  std::cout << "\033[" << linesUp << "A";     // move up
+  std::cout << "\r\033[K";                     // clear line
+  std::cout << "[" << state << "] " << src;    // print new state
+  std::cout << "\033[" << linesUp << "B";     // move back down
+  std::cout.flush();
+}

--- a/src/Progress.cpp
+++ b/src/Progress.cpp
@@ -1,15 +1,24 @@
 #include "Progress.hpp"
 
-CompileProgress::CompileProgress(const std::vector<std::string>& sources) {
+CompileProgress::CompileProgress(const std::vector<std::string>& sources,
+                                 bool quiet) {
   sources_ = sources;
-  for (size_t i = 0; i < sources.size(); ++i) {
-    index_[sources[i]] = i;
-    std::cout << "[waiting] " << sources[i] << std::endl;
+  quiet_ = quiet;
+  if (!quiet_) {
+    for (size_t i = 0; i < sources.size(); ++i) {
+      index_[sources[i]] = i;
+      std::cout << "[waiting] " << sources[i] << std::endl;
+    }
+    std::cout.flush();
+  } else {
+    for (size_t i = 0; i < sources.size(); ++i) {
+      index_[sources[i]] = i;
+    }
   }
-  std::cout.flush();
 }
 
 void CompileProgress::update(const std::string& src, const std::string& state) {
+  if (quiet_) return;
   auto it = index_.find(src);
   if (it == index_.end()) return;
   size_t line = it->second;

--- a/src/Progress.cpp
+++ b/src/Progress.cpp
@@ -23,9 +23,9 @@ void CompileProgress::update(const std::string& src, const std::string& state) {
   if (it == index_.end()) return;
   size_t line = it->second;
   size_t linesUp = sources_.size() - line;
-  std::cout << "\033[" << linesUp << "A";     // move up
-  std::cout << "\r\033[K";                     // clear line
-  std::cout << "[" << state << "] " << src;    // print new state
-  std::cout << "\033[" << linesUp << "B";     // move back down
+  std::cout << "\033[" << linesUp << "A";    // move up
+  std::cout << "\r\033[K";                   // clear line
+  std::cout << "[" << state << "] " << src;  // print new state
+  std::cout << "\033[" << linesUp << "B";    // move back down
   std::cout.flush();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,14 +69,14 @@ int main(int argc, char *argv[]) {
   if (value == "build") {
     cfg::Config config = cfg::loadConfig(cli.configFile);
     config.debug = cli.debug;
-    config.outPutFile = cli.outputFile;
+    if (!cli.outputFile.empty()) config.outPutFile = cli.outputFile;
     runConfig(config, libPathA, 'e');
     return 0;
   }
   if (value == "run") {
     cfg::Config config = cfg::loadConfig(cli.configFile);
     config.debug = cli.debug;
-    config.outPutFile = cli.outputFile;
+    if (!cli.outputFile.empty()) config.outPutFile = cli.outputFile;
     if (runConfig(config, libPathA, 'e')) {
       auto of = config.outPutFile;
       if (config.outPutFile[0] != '.' && config.outPutFile[1] != '/') {
@@ -89,7 +89,7 @@ int main(int argc, char *argv[]) {
   if (value == "test") {
     cfg::Config config = cfg::loadConfig(cli.configFile);
     config.debug = cli.debug;
-    config.outPutFile = cli.outputFile;
+    if (!cli.outputFile.empty()) config.outPutFile = cli.outputFile;
     if (runConfig(config, libPathA, 't')) {
       [[maybe_unused]] int rc = system("./bin/a.test");
     }
@@ -190,6 +190,10 @@ int main(int argc, char *argv[]) {
     [[maybe_unused]] int rc = system(install_command.c_str());
   }
   std::string outputFile = cli.outputFile;
+  if (outputFile.empty() && !cli.args.empty()) {
+    outputFile = cli.args[0];
+  }
+  if (outputFile.empty()) outputFile = "out.s";
   if (std::filesystem::exists(value)) {
     build(value, outputFile, cfg::Mutability::Promiscuous, cli.debug);
   } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,8 +18,8 @@
 #include "Parser/Lower.hpp"
 #include "Parser/Parser.hpp"
 #include "PreProcessor.hpp"
-#include "Scanner.hpp"
 #include "Progress.hpp"
+#include "Scanner.hpp"
 
 std::string preProcess(std::string input);
 std::string getExePath();
@@ -58,7 +58,6 @@ int main(int argc, char *argv[]) {
       return 1;
     }
     std::string pName = cli.args[0];
-    std::cout << "creating " << pName << '\n';
     if (cli.args.size() == 2 && cli.args[1] == "lib") {
       libTemplate(pName);
     } else {
@@ -78,6 +77,7 @@ int main(int argc, char *argv[]) {
     config.debug = cli.debug;
     if (!cli.outputFile.empty()) config.outPutFile = cli.outputFile;
     if (runConfig(config, libPathA, 'e')) {
+      std::cout << "running " << config.outPutFile << '\n';
       auto of = config.outPutFile;
       if (config.outPutFile[0] != '.' && config.outPutFile[1] != '/') {
         of = "./" + config.outPutFile;
@@ -533,8 +533,10 @@ bool runConfig(cfg::Config &config, const std::string &libPath, char pmode) {
   }
 
   std::vector<std::string> sources;
-  for (const auto &mod : config.modules) sources.push_back("./src/" + mod + ".af");
-  for (const auto &file : config.cFiles) sources.push_back("./src/" + file + ".c");
+  for (const auto &mod : config.modules)
+    sources.push_back("./src/" + mod + ".af");
+  for (const auto &file : config.cFiles)
+    sources.push_back("./src/" + file + ".c");
 
   CompileProgress progress(sources, gQuiet);
   if (!gQuiet) gProgress = &progress;
@@ -634,5 +636,6 @@ bool runConfig(cfg::Config &config, const std::string &libPath, char pmode) {
     }
   }
   gProgress = nullptr;
+  std::cout << std::endl;
   return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,7 +77,6 @@ int main(int argc, char *argv[]) {
     config.debug = cli.debug;
     if (!cli.outputFile.empty()) config.outPutFile = cli.outputFile;
     if (runConfig(config, libPathA, 'e')) {
-      std::cout << "running " << config.outPutFile << '\n';
       auto of = config.outPutFile;
       if (config.outPutFile[0] != '.' && config.outPutFile[1] != '/') {
         of = "./" + config.outPutFile;

--- a/test/test_BuildLogging.cpp
+++ b/test/test_BuildLogging.cpp
@@ -1,7 +1,7 @@
 #include <filesystem>
 #include <fstream>
-#include <sstream>
 #include <iostream>
+#include <sstream>
 #include <string>
 
 #include "Configs.hpp"
@@ -20,8 +20,8 @@ TEST_CASE("build logs compile states", "[build]") {
   std::stringstream buffer;
   auto *oldBuf = std::cout.rdbuf(buffer.rdbuf());
 
-  bool result = build("tmp/simple.af", "tmp/simple.s", cfg::Mutability::Strict,
-                       false);
+  bool result =
+      build("tmp/simple.af", "tmp/simple.s", cfg::Mutability::Strict, false);
   std::cout.flush();
   std::cout.rdbuf(oldBuf);
 

--- a/test/test_BuildLogging.cpp
+++ b/test/test_BuildLogging.cpp
@@ -1,0 +1,37 @@
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <iostream>
+#include <string>
+
+#include "Configs.hpp"
+#include "catch.hpp"
+
+bool build(std::string path, std::string output, cfg::Mutability mutability,
+           bool debug);
+
+TEST_CASE("build logs compile states", "[build]") {
+  namespace fs = std::filesystem;
+  fs::create_directories("tmp");
+  std::ofstream ofs("tmp/simple.af");
+  ofs << "int main(){return 0;};";
+  ofs.close();
+
+  std::stringstream buffer;
+  auto *oldBuf = std::cout.rdbuf(buffer.rdbuf());
+
+  bool result = build("tmp/simple.af", "tmp/simple.s", cfg::Mutability::Strict,
+                       false);
+  std::cout.flush();
+  std::cout.rdbuf(oldBuf);
+
+  fs::remove("tmp/simple.af");
+  if (fs::exists("tmp/simple.s")) fs::remove("tmp/simple.s");
+  fs::remove("tmp");
+
+  REQUIRE(result);
+  std::string out = buffer.str();
+  REQUIRE(out.find("[parsing] tmp/simple.af") != std::string::npos);
+  REQUIRE(out.find("[generating] tmp/simple.af") != std::string::npos);
+  REQUIRE(out.find("[done] tmp/simple.af") != std::string::npos);
+}

--- a/test/test_CLI.cpp
+++ b/test/test_CLI.cpp
@@ -11,3 +11,11 @@ TEST_CASE("CLI parses flags", "[cli]") {
   REQUIRE(opts.outputFile == "foo.s");
   REQUIRE(opts.command == "build");
 }
+
+TEST_CASE("CLI default output empty without flag", "[cli]") {
+  const char *argv[] = {"aflat", "build"};
+  CommandLineOptions opts;
+  REQUIRE(parseCommandLine(2, (char **)argv, opts));
+  REQUIRE(opts.outputFile.empty());
+  REQUIRE(opts.command == "build");
+}

--- a/test/test_CLI.cpp
+++ b/test/test_CLI.cpp
@@ -2,11 +2,12 @@
 #include "catch.hpp"
 
 TEST_CASE("CLI parses flags", "[cli]") {
-  const char *argv[] = {"aflat", "-d", "-t", "-o", "foo.s", "build"};
+  const char *argv[] = {"aflat", "-d", "-t", "-q", "-o", "foo.s", "build"};
   CommandLineOptions opts;
-  REQUIRE(parseCommandLine(6, (char **)argv, opts));
+  REQUIRE(parseCommandLine(7, (char **)argv, opts));
   REQUIRE(opts.debug == true);
   REQUIRE(opts.traceAlerts == true);
+  REQUIRE(opts.quiet == true);
   REQUIRE(opts.outputFile == "foo.s");
   REQUIRE(opts.command == "build");
 }


### PR DESCRIPTION
## Summary
- add compile progress logging in `build`, `compileCFile`, and `runConfig`
- expose `AFLAT_TEST` flag so tests can link against `main.cpp`
- test new logging behavior in `test_BuildLogging.cpp`

## Testing
- `cmake -S . -B build`
- `cmake --build build -j2`
- `./bin/a.test`

------
https://chatgpt.com/codex/tasks/task_e_68577dad1ef08328b313ce005d232204