### PR TITLE
Add --lib flag for project creation

### DIFF
--- a/Docs.md
+++ b/Docs.md
@@ -864,6 +864,7 @@ The package manager is used to create a project.  The syntax is:
 ```bash
 aflat make <project name>
 ```
+Add `--lib` before `make` to generate a library template without a `main` file.
 The project name is will be the name of the directory that will be created. It will create a head, src, and bin directory.  The head directory will contain the header files for the project.  The src directory will contain the source files for the project.  The bin directory will contain the compiled object files for the project.  It will also create an `aflat.cfg` file using an INI format for build settings and dependencies.
 
 ## Building a Project

--- a/README.md
+++ b/README.md
@@ -41,9 +41,13 @@ Or adding the aflat bin to your path.
 This readme assumes that the aflat bin directory is in your path or an alias is set.
 
 ### Creating a new project
-Creating a new aflat progect is as simple as running the binary with the command 'make'
+Creating a new aflat project is as simple as running the binary with the command `make`
 ```bash
 aflat make <project_name>
+```
+To create a library project omit the hello world `main` by using `--lib`:
+```bash
+aflat --lib make <project_name>
 ```
 
 ### Hello World

--- a/first-steps.MD
+++ b/first-steps.MD
@@ -16,6 +16,7 @@ To create the tutorial project, run the following command in your project direct
 ```bash
 aflat make tutorial
 ```
+Use `--lib` before `make` if you want a library project instead of an executable.
 
 The tutorial project will have been created in the `tutorial` directory.  The tutorial project will have a `aflat.cfg` file that will tell the aflat build system what to build and link.  The tutorial project will have a `src/main.af` file that will be the entry point for the project. It will also have a `src/test/test.af` file that is will be used to test the project with the `aflat test` command.
 

--- a/include/CLI.hpp
+++ b/include/CLI.hpp
@@ -9,6 +9,7 @@ struct CommandLineOptions {
   bool quiet = false;
   bool updateDeps = false;
   bool cleanDeps = false;
+  bool library = false;
   std::string installName;
   std::string outputFile;  // set via -o when compiling single files
   std::string configFile = "aflat.cfg";

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -15,10 +15,11 @@ bool parseCommandLine(int argc, char **argv, CommandLineOptions &opts) {
                                  {"name", required_argument, nullptr, 'n'},
                                  {"update-deps", no_argument, nullptr, 'U'},
                                  {"clean-deps", no_argument, nullptr, 'K'},
+                                 {"lib", no_argument, nullptr, 'L'},
                                  {nullptr, 0, nullptr, 0}};
 
   int opt;
-  while ((opt = getopt_long(argc, argv, "hdo:tc:qUKn:", longOptions,
+  while ((opt = getopt_long(argc, argv, "hdo:tc:qUKn:L", longOptions,
                             nullptr)) != -1) {
     switch (opt) {
       case 'o':
@@ -44,6 +45,9 @@ bool parseCommandLine(int argc, char **argv, CommandLineOptions &opts) {
         break;
       case 'K':
         opts.cleanDeps = true;
+        break;
+      case 'L':
+        opts.library = true;
         break;
       case 'h':
       case '?':
@@ -88,5 +92,6 @@ void printUsage(const char *prog) {
       << "  -t, --trace-alerts  Trace CodeGenerator alerts\n"
       << "  -U, --update-deps   Refresh git dependencies\n"
       << "  -K, --clean-deps    Remove all git dependencies\n"
+      << "  -L, --lib           Create a library project with make\n"
       << "  -h, --help          Display this help message\n";
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[]) {
       return 1;
     }
     std::string pName = cli.args[0];
-    if (cli.args.size() == 2 && cli.args[1] == "lib") {
+    if (cli.library || (cli.args.size() == 2 && cli.args[1] == "lib")) {
       libTemplate(pName);
     } else {
       buildTemplate(pName);

--- a/test/test_CLI.cpp
+++ b/test/test_CLI.cpp
@@ -36,3 +36,13 @@ TEST_CASE("CLI name flag", "[cli]") {
   REQUIRE(opts.installName == "foo");
   REQUIRE(opts.command == "install");
 }
+
+TEST_CASE("CLI library flag", "[cli]") {
+  const char *argv[] = {"aflat", "--lib", "make", "proj"};
+  CommandLineOptions opts;
+  REQUIRE(parseCommandLine(4, (char **)argv, opts));
+  REQUIRE(opts.library == true);
+  REQUIRE(opts.command == "make");
+  REQUIRE(opts.args.size() == 1);
+  REQUIRE(opts.args[0] == std::string("proj"));
+}


### PR DESCRIPTION
## Summary
- support `--lib` flag in CLI to create library projects
- update project template logic to check library flag
- document the new `--lib` flag
- add unit test for new CLI flag

## Testing
- `cmake --build build -j 2`
- `./bin/a.test`

------
https://chatgpt.com/codex/tasks/task_e_6872d184c3e08328ad24648422c6caad