### PR TITLE
Add setOffset to CodeGenerator

### DIFF
--- a/include/CodeGenerator/CodeGenerator.hpp
+++ b/include/CodeGenerator/CodeGenerator.hpp
@@ -100,6 +100,8 @@ class CodeGenerator {
   gen::Expr genArithmetic(asmc::ArithInst *, ast::Compound compound,
                           asmc::File &OutputFile);
   asmc::File memMove(std::string from, std::string to, int bytes);
+  asmc::File setOffset(std::string to, int offset, std::string from,
+                       asmc::Size size);
   ast::Expr *imply(ast::Expr *expr, std::string typeName);
   bool canAssign(ast::Type type, std::string typeName, std::string fmt,
                  bool strict = false);

--- a/src/CodeGenerator/CodeGenerator.cpp
+++ b/src/CodeGenerator/CodeGenerator.cpp
@@ -394,3 +394,64 @@ asmc::File gen::CodeGenerator::memMove(std::string from, std::string to,
 
   return file;
 }
+
+asmc::File gen::CodeGenerator::setOffset(std::string to, int offset,
+                                         std::string from, asmc::Size size) {
+  asmc::File file;
+
+  asmc::Push *pushRdi = new asmc::Push();
+  pushRdi->op = this->registers["%rdi"]->get(asmc::QWord);
+  pushRdi->size = asmc::QWord;
+  pushRdi->logicalLine = this->logicalLine;
+  file.text << pushRdi;
+
+  asmc::Push *pushRax = new asmc::Push();
+  pushRax->op = this->registers["%rax"]->get(asmc::QWord);
+  pushRax->size = asmc::QWord;
+  pushRax->logicalLine = this->logicalLine;
+  file.text << pushRax;
+
+  asmc::Mov *movPtr = new asmc::Mov();
+  movPtr->from = to;
+  movPtr->to = this->registers["%rdi"]->get(asmc::QWord);
+  movPtr->size = asmc::QWord;
+  movPtr->logicalLine = this->logicalLine;
+  file.text << movPtr;
+
+  if (offset != 0) {
+    asmc::Add *addOffset = new asmc::Add();
+    addOffset->op1 = "$" + std::to_string(offset);
+    addOffset->op2 = this->registers["%rdi"]->get(asmc::QWord);
+    addOffset->size = asmc::QWord;
+    addOffset->logicalLine = this->logicalLine;
+    file.text << addOffset;
+  }
+
+  asmc::Mov *movVal = new asmc::Mov();
+  movVal->from = from;
+  movVal->to = this->registers["%rax"]->get(size);
+  movVal->size = size;
+  movVal->logicalLine = this->logicalLine;
+  file.text << movVal;
+
+  asmc::Mov *store = new asmc::Mov();
+  store->from = this->registers["%rax"]->get(size);
+  store->to = '(' + this->registers["%rdi"]->get(asmc::QWord) + ')';
+  store->size = size;
+  store->logicalLine = this->logicalLine;
+  file.text << store;
+
+  asmc::Pop *popRax = new asmc::Pop();
+  popRax->op = this->registers["%rax"]->get(asmc::QWord);
+  popRax->size = asmc::QWord;
+  popRax->logicalLine = this->logicalLine;
+  file.text << popRax;
+
+  asmc::Pop *popRdi = new asmc::Pop();
+  popRdi->op = this->registers["%rdi"]->get(asmc::QWord);
+  popRdi->size = asmc::QWord;
+  popRdi->logicalLine = this->logicalLine;
+  file.text << popRdi;
+
+  return file;
+}

--- a/test/test_CodeGenerator.cpp
+++ b/test/test_CodeGenerator.cpp
@@ -105,3 +105,47 @@ TEST_CASE("memMove generates copy loop", "[memmove]") {
   REQUIRE(popCnt);
   REQUIRE(popA);
 }
+
+TEST_CASE("setOffset stores value at pointer offset", "[setOffset]") {
+  auto parser = parse::Parser();
+  gen::CodeGenerator gen("mod", parser, "",
+                         std::filesystem::current_path().string());
+
+  auto file = gen.setOffset("%rbx", 4, "$0xff", asmc::Byte);
+  bool movePtr = false;
+  bool addOff = false;
+  bool moveVal = false;
+  bool storeVal = false;
+  bool pushRdi = false;
+  bool pushRax = false;
+  bool popRdi = false;
+  bool popRax = false;
+
+  for (int i = 0; i < file.text.size(); ++i) {
+    if (auto *m = dynamic_cast<asmc::Mov *>(file.text.get(i))) {
+      if (m->from == "%rbx" && m->to == "%rdi") movePtr = true;
+      if (m->from == "$0xff" && m->to == "%al") moveVal = true;
+      if (m->from == "%al" && m->to == "(%rdi)") storeVal = true;
+    }
+    if (auto *a = dynamic_cast<asmc::Add *>(file.text.get(i))) {
+      if (a->op1 == "$4" && a->op2 == "%rdi") addOff = true;
+    }
+    if (auto *p = dynamic_cast<asmc::Push *>(file.text.get(i))) {
+      if (p->op == "%rdi") pushRdi = true;
+      if (p->op == "%rax") pushRax = true;
+    }
+    if (auto *po = dynamic_cast<asmc::Pop *>(file.text.get(i))) {
+      if (po->op == "%rdi") popRdi = true;
+      if (po->op == "%rax") popRax = true;
+    }
+  }
+
+  REQUIRE(movePtr);
+  REQUIRE(addOff);
+  REQUIRE(moveVal);
+  REQUIRE(storeVal);
+  REQUIRE(pushRdi);
+  REQUIRE(pushRax);
+  REQUIRE(popRdi);
+  REQUIRE(popRax);
+}


### PR DESCRIPTION
## Summary
- implement `CodeGenerator::setOffset` for writing a value at a pointer plus offset
- expose new method in header
- test new function in CodeGenerator tests

## Testing
- `cmake --build build --target a.test`
- `./bin/a.test`

------
https://chatgpt.com/codex/tasks/task_e_6875281845ec8328a05cb2ce53896ba8