### PR TITLE
Use std::vector for LinkedList

### DIFF
--- a/include/LinkedList.hpp
+++ b/include/LinkedList.hpp
@@ -1,6 +1,9 @@
 #ifndef LINKS
 #define LINKS
 
+#include <algorithm>
+#include <vector>
+
 #include "Exceptions.hpp"
 
 namespace links {
@@ -17,346 +20,204 @@ class LinkedList {
  public:
   bool (*foo)(T, T);
   int count;
-
   Node<T> *head;
   Node<T> *pos;
+
   LinkedList();
 
-  /*Push a new value to the top of the list*/
   void push(T value);
-
-  /*push with operator*/
-  void operator<<(T value);
-
-  /*Insert at an index*/
+  void operator<<(T value) { push(value); }
   void insert(T value, int index);
-
-  /*void insert from top*/
   void insert_top(T value, int index);
-  /*Reverses the direction of the list*/
   void invert();
-
-  /*attaches the head of another linked list to the tail of this one*/
-  void stitch(links::LinkedList<T> l);
-
-  /*stitches the head of this linked list to the tail of another one and sets
-   * the head of the other as the new head*/
-  void istitch(links::LinkedList<T> l);
-
-  /*clears the list and sets the head to nullptr*/
+  void stitch(LinkedList<T> l);
+  void istitch(LinkedList<T> l);
   void clear();
-
-  /*returns the value at the index*/
   T get(int index);
-
-  /*returns the number of nodes in the list*/
   int size();
-
-  /*like size but from the pos*/
   int trail();
-
-  /*set the nth items next to nullptr*/
   void terminate(int n);
-
-  /*Pop removes the top element for the list
-  Behaves like a stack*/
   T pop();
-
-  /*Observes the first node on the list and returns its value without
-  popping it.*/
   T peek();
-
-  /*search with passed in logic*/
   template <typename Z>
-  T *search(bool (*foo)(T, Z), Z input);
-
-  /*search for a value*/
+  T *search(bool (*f)(T, Z), Z input);
   T *operator[](T input);
-
-  /*appends a node to the end of the list*/
   T *append(T input);
-
-  /*A list of functions to use without mutating the List */
-
-  /*Return the element pointed to by the pos Pointer and shifts the pos pointer
-   * by one*/
   T shift();
-
-  /*Return the element pointed to by the pos pointer without shifting*/
   T touch();
-
-  /*insert at the position of the pos pointer*/
-  void place(T);
-
+  void place(T value);
   void reset();
+
+ private:
+  std::vector<Node<T>> nodes;
+  void rebuild();
 };
+
 }  // namespace links
 
+// Implementation
+
+namespace links {
+
 template <typename T>
-int links::LinkedList<T>::size() {
-  int count = 0;
-  Node<T> *temp = head;
-  while (temp != nullptr) {
-    count++;
-    temp = temp->next;
+LinkedList<T>::LinkedList()
+    : foo(nullptr), count(0), head(nullptr), pos(nullptr) {}
+
+template <typename T>
+void LinkedList<T>::rebuild() {
+  head = nodes.empty() ? nullptr : &nodes.front();
+  for (size_t i = 0; i < nodes.size(); ++i) {
+    nodes[i].next = (i + 1 < nodes.size()) ? &nodes[i + 1] : nullptr;
   }
-  return count;
+  pos = head;
+  count = static_cast<int>(nodes.size());
 }
 
 template <typename T>
-int links::LinkedList<T>::trail() {
-  int count = 0;
-  Node<T> *temp = pos;
-  while (temp != nullptr) {
-    count++;
-    temp = temp->next;
-  }
-  return count;
+void LinkedList<T>::push(T value) {
+  nodes.insert(nodes.begin(), Node<T>{value, nullptr});
+  rebuild();
 }
 
 template <typename T>
-void links::LinkedList<T>::terminate(int n) {
-  Node<T> *temp = head;
-  for (int i = 0; i < n; i++) {
-    temp = temp->next;
-  }
-  temp->next = nullptr;
+void LinkedList<T>::insert(T value, int index) {
+  if (index < 1 || index > static_cast<int>(nodes.size()))
+    throw err::Exception("Index Out of Range");
+  nodes.insert(nodes.end() - index + 1, Node<T>{value, nullptr});
+  rebuild();
 }
 
 template <typename T>
-T links::LinkedList<T>::get(int index) {
-  if (index < 0 || index > this->size()) {
+void LinkedList<T>::insert_top(T value, int index) {
+  if (index < 0 || index > static_cast<int>(nodes.size()))
+    throw err::Exception("Index Out of Range");
+  nodes.insert(nodes.begin() + index, Node<T>{value, nullptr});
+  rebuild();
+}
+
+template <typename T>
+void LinkedList<T>::invert() {
+  std::reverse(nodes.begin(), nodes.end());
+  rebuild();
+}
+
+template <typename T>
+void LinkedList<T>::stitch(LinkedList<T> l) {
+  nodes.insert(nodes.end(), l.nodes.begin(), l.nodes.end());
+  rebuild();
+}
+
+template <typename T>
+void LinkedList<T>::istitch(LinkedList<T> l) {
+  nodes.insert(nodes.begin(), l.nodes.begin(), l.nodes.end());
+  rebuild();
+}
+
+template <typename T>
+void LinkedList<T>::clear() {
+  nodes.clear();
+  rebuild();
+}
+
+template <typename T>
+T LinkedList<T>::get(int index) {
+  if (index < 0 || index >= static_cast<int>(nodes.size()))
     throw err::Exception("Index Out of Bounds");
-    ;
-  }
-  Node<T> *current = head;
-  for (int i = 0; i < index; i++) {
-    current = current->next;
-  }
-  return current->data;
+  return nodes[index].data;
 }
 
 template <typename T>
-T *links::LinkedList<T>::append(T input) {
-  Node<T> *temp = new Node<T>;
-  temp->data = input;
-  temp->next = nullptr;
-  if (head == nullptr) {
-    head = temp;
-  } else {
-    Node<T> *current = head;
-    while (current->next != nullptr) {
-      current = current->next;
-    }
-    current->next = temp;
-  }
-  count++;
-  return &temp->data;
+int LinkedList<T>::size() {
+  return static_cast<int>(nodes.size());
 }
 
 template <typename T>
-void links::LinkedList<T>::reset() {
-  this->pos = this->head;
-  if (this->trail() > this->count) {
-    this->terminate(this->count - 1);
+int LinkedList<T>::trail() {
+  int c = 0;
+  Node<T> *tmp = pos;
+  while (tmp) {
+    ++c;
+    tmp = tmp->next;
   }
+  return c;
+}
+
+template <typename T>
+void LinkedList<T>::terminate(int n) {
+  if (n < 0 || n >= static_cast<int>(nodes.size())) return;
+  if (n + 1 < static_cast<int>(nodes.size())) nodes[n].next = nullptr;
+}
+
+template <typename T>
+T LinkedList<T>::pop() {
+  if (nodes.empty()) throw err::Exception("Pop from empty list");
+  T val = nodes.front().data;
+  nodes.erase(nodes.begin());
+  rebuild();
+  return val;
+}
+
+template <typename T>
+T LinkedList<T>::peek() {
+  if (nodes.empty()) throw err::Exception("Peek from empty list");
+  return nodes.front().data;
+}
+
+template <typename T>
+T *LinkedList<T>::append(T input) {
+  nodes.push_back(Node<T>{input, nullptr});
+  rebuild();
+  return &nodes.back().data;
+}
+
+template <typename T>
+T *LinkedList<T>::operator[](T input) {
+  if (!foo) return nullptr;
+  for (auto &n : nodes) {
+    if (foo(n.data, input)) return &n.data;
+  }
+  return nullptr;
 }
 
 template <typename T>
 template <typename Z>
-T *links::LinkedList<T>::search(bool (*foo)(T, Z), Z input) {
-  links::Node<T> *pointer = this->head;
-  if (this->head == nullptr) return nullptr;
-  if ((*foo)(this->head->data, input)) return &this->head->data;
-  while (pointer->next != nullptr) {
-    pointer = pointer->next;
-    if (foo(pointer->data, input)) {
-      return &pointer->data;
-    }
+T *LinkedList<T>::search(bool (*f)(T, Z), Z input) {
+  for (auto &n : nodes) {
+    if (f(n.data, input)) return &n.data;
   }
   return nullptr;
 }
 
 template <typename T>
-T *links::LinkedList<T>::operator[](T input) {
-  links::Node<T> *pointer = this->head;
-  if (this->head == nullptr) return nullptr;
-  if ((*foo)(this->head->data, input)) return &this->head->data;
-  while (pointer->next != nullptr) {
-    pointer = pointer->next;
-    if (foo(pointer->data, input)) {
-      return &pointer->data;
-    }
-  }
-  return nullptr;
-}
-
-template <typename T>
-links::LinkedList<T>::LinkedList() {
-  this->count = 0;
-  head = nullptr;
-}
-
-template <typename T>
-void links::LinkedList<T>::clear() {
-  if (this->count > 0) {
-    while (this->count > 0) {
-      this->pop();
-    }
-  }
-  this->count = 0;
-  this->head = nullptr;
-  this->pos = nullptr;
-}
-
-template <typename T>
-void links::LinkedList<T>::push(T value) {
-  this->count += 1;
-  Node<T> *push = new Node<T>();
-  push->next = this->head;
-  push->data = value;
-  this->head = push;
-  this->pos = this->head;
-}
-
-template <typename T>
-void links::LinkedList<T>::insert(T value, int index) {
-  Node<T> *curr = this->head;
-  int i = 0;
-  int count = this->size();
-  while (curr != nullptr) {
-    if (i == count - index) {
-      Node<T> *New = new Node<T>();
-      New->data = value;
-      New->next = curr->next;
-      curr->next = New;
-      this->count++;
-      return;
-    }
-    curr = curr->next;
-    i++;
-  }
-  throw err::Exception("Index Out of Range");
-};
-
-template <typename T>
-void links::LinkedList<T>::insert_top(T value, int index) {
-  Node<T> *curr = this->head;
-  int i = 0;
-  while (curr != nullptr) {
-    if (i == index) {
-      Node<T> *New = new Node<T>();
-      New->data = value;
-      New->next = curr;
-      this->head = New;
-      this->count++;
-      this->pos = New;
-      return;
-    }
-    curr = curr->next;
-    i++;
-  }
-  throw err::Exception("Index Out of Range");
-}
-
-template <typename T>
-void links::LinkedList<T>::operator<<(T value) {
-  this->count += 1;
-  Node<T> *push = new Node<T>();
-  push->next = this->head;
-  push->data = value;
-  this->head = push;
-}
-
-template <typename T>
-void links::LinkedList<T>::invert() {
-  Node<T> *prev = nullptr;
-  Node<T> *curr = this->head;
-  Node<T> *next = nullptr;
-
-  while (curr != nullptr) {
-    next = curr->next;
-    curr->next = prev;
-    prev = curr;
-    curr = next;
-  }
-
-  this->head = prev;
-  this->pos = this->head;
-}
-
-template <typename T>
-T links::LinkedList<T>::pop() {
-  this->count -= 1;
-  T data = this->head->data;
-  Node<T> *popper = this->head;
-  this->head = this->head->next;
-  this->pos = this->head;
-  delete popper;
+T LinkedList<T>::shift() {
+  if (!pos) throw err::Exception("Position Pointer is null");
+  T data = pos->data;
+  pos = pos->next;
   return data;
 }
 
 template <typename T>
-T links::LinkedList<T>::shift() {
-  if (this->pos == nullptr) throw err::Exception("Position Pointer is null");
-
-  T data = this->pos->data;
-  this->pos = this->pos->next;
-  return data;
+T LinkedList<T>::touch() {
+  if (!pos) throw err::Exception("Position Pointer is null cannot touch");
+  return pos->data;
 }
 
 template <typename T>
-T links::LinkedList<T>::peek() {
-  return this->head->data;
-}
-
-template <typename T>
-T links::LinkedList<T>::touch() {
-  if (this->pos == nullptr)
-    throw err::Exception("Position Pointer is null cannot touch");
-  return this->pos->data;
-};
-
-template <typename T>
-void links::LinkedList<T>::place(T value) {
-  // get the index of pos
+void LinkedList<T>::place(T value) {
   int index = 0;
-  Node<T> *curr = this->head;
-  while (curr != this->pos) {
+  Node<T> *curr = head;
+  while (curr && curr != pos) {
     curr = curr->next;
-    index++;
+    ++index;
   }
-  // insert at the index
-  this->insert_top(value, index);
-};
-
-template <typename T>
-void links::LinkedList<T>::stitch(LinkedList<T> l) {
-  links::Node<T> *pointer = head;
-  this->count += l.count;
-  if (pointer == nullptr) {
-    this->head = l.head;
-  } else {
-    while (pointer->next != nullptr) {
-      pointer = pointer->next;
-    }
-    pointer->next = l.head;
-  }
+  insert_top(value, index);
 }
 
 template <typename T>
-void links::LinkedList<T>::istitch(LinkedList<T> l) {
-  links::Node<T> *pointer = l.head;
-  this->count += l.count;
-  if (pointer == nullptr) {
-    return;
-  } else {
-    while ((pointer->next != nullptr)) {
-      pointer = pointer->next;
-    }
-    pointer->next = head;
-    this->head = l.head;
-  }
+void LinkedList<T>::reset() {
+  rebuild();
 }
+
+}  // namespace links
 
 #endif


### PR DESCRIPTION
## Summary
- implement LinkedList as a wrapper around `std::vector`
- keep the public API intact with head/pos nodes rebuilt from the vector

## Testing
- `make` *(fails: Parser/AST/Statements/Match.hpp missing)*

------
https://chatgpt.com/codex/tasks/task_e_6875a559d15883288489df94efbb24d9