### PR TITLE
Fix segmentation fault in match parser

### DIFF
--- a/include/Parser/AST/Statements/Match.hpp
+++ b/include/Parser/AST/Statements/Match.hpp
@@ -15,7 +15,7 @@ class Match : public Expr {
   struct Pattern {
     std::string aliasName;
     std::optional<std::string> veriableName;
-    Pattern(links::LinkedList<lex::Token *> tokens);
+    Pattern(links::LinkedList<lex::Token *> &tokens);
     Pattern() = default;
     Pattern(std::string aliasName, std::optional<std::string> veriableName)
         : aliasName(std::move(aliasName)),

--- a/src/Parser/AST/Statements/Match.cpp
+++ b/src/Parser/AST/Statements/Match.cpp
@@ -5,7 +5,7 @@
 
 namespace ast {
 
-Match::Pattern::Pattern(links::LinkedList<lex::Token *> tokens) {
+Match::Pattern::Pattern(links::LinkedList<lex::Token *> &tokens) {
   auto name = dynamic_cast<lex::LObj *>(tokens.pop());
   if (name == nullptr) {
     throw err::Exception("Line: " + std::to_string(tokens.peek()->lineCount) +


### PR DESCRIPTION
## Summary
- fix `Match::Pattern` to take tokens by reference
- update implementation accordingly

## Testing
- `cmake --build build --target aflat -j$(nproc)`
- `./bin/aflat test_union.af -o test_union.s`
- `./bin/a.test`

------
https://chatgpt.com/codex/tasks/task_e_6875bdf323a08328943e3b7281fc23af