### PR TITLE
Modernize linked lists

### DIFF
--- a/include/LinkedListS.hpp
+++ b/include/LinkedListS.hpp
@@ -12,6 +12,78 @@ class SLinkedList {
 
   Node<T> *head;
   SLinkedList();
+  ~SLinkedList();
+  SLinkedList(const SLinkedList &other);
+  SLinkedList &operator=(const SLinkedList &other);
+  SLinkedList(SLinkedList &&other) noexcept;
+  SLinkedList &operator=(SLinkedList &&other) noexcept;
+
+  class iterator {
+   public:
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = T;
+    using pointer = T *;
+    using reference = T &;
+
+    iterator(Node<T> *n) : node(n) {}
+    reference operator*() const { return node->data; }
+    pointer operator->() const { return &node->data; }
+    iterator &operator++() {
+      node = node ? node->next : nullptr;
+      return *this;
+    }
+    iterator operator++(int) {
+      iterator tmp(*this);
+      ++(*this);
+      return tmp;
+    }
+    friend bool operator==(const iterator &a, const iterator &b) {
+      return a.node == b.node;
+    }
+    friend bool operator!=(const iterator &a, const iterator &b) {
+      return a.node != b.node;
+    }
+
+   private:
+    Node<T> *node;
+  };
+
+  class const_iterator {
+   public:
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = T;
+    using pointer = const T *;
+    using reference = const T &;
+
+    const_iterator(const Node<T> *n) : node(n) {}
+    reference operator*() const { return node->data; }
+    pointer operator->() const { return &node->data; }
+    const_iterator &operator++() {
+      node = node ? node->next : nullptr;
+      return *this;
+    }
+    const_iterator operator++(int) {
+      const_iterator tmp(*this);
+      ++(*this);
+      return tmp;
+    }
+    friend bool operator==(const const_iterator &a, const const_iterator &b) {
+      return a.node == b.node;
+    }
+    friend bool operator!=(const const_iterator &a, const const_iterator &b) {
+      return a.node != b.node;
+    }
+
+   private:
+    const Node<T> *node;
+  };
+
+  iterator begin() { return iterator(head); }
+  iterator end() { return iterator(nullptr); }
+  const_iterator begin() const { return const_iterator(head); }
+  const_iterator end() const { return const_iterator(nullptr); }
 
   /*Push a new value to the top of the list*/
   void push(T value);
@@ -77,6 +149,52 @@ links::SLinkedList<T, Z>::SLinkedList() {
 }
 
 template <typename T, typename Z>
+links::SLinkedList<T, Z>::~SLinkedList() {
+  clear();
+}
+
+template <typename T, typename Z>
+links::SLinkedList<T, Z>::SLinkedList(const SLinkedList &other)
+    : SLinkedList() {
+  for (const auto &v : other) push(v);
+}
+
+template <typename T, typename Z>
+links::SLinkedList<T, Z> &links::SLinkedList<T, Z>::operator=(
+    const SLinkedList &other) {
+  if (this != &other) {
+    clear();
+    for (const auto &v : other) push(v);
+  }
+  return *this;
+}
+
+template <typename T, typename Z>
+links::SLinkedList<T, Z>::SLinkedList(SLinkedList &&other) noexcept {
+  foo = other.foo;
+  count = other.count;
+  head = other.head;
+  other.head = nullptr;
+  other.count = 0;
+  other.foo = nullptr;
+}
+
+template <typename T, typename Z>
+links::SLinkedList<T, Z> &links::SLinkedList<T, Z>::operator=(
+    SLinkedList &&other) noexcept {
+  if (this != &other) {
+    clear();
+    foo = other.foo;
+    count = other.count;
+    head = other.head;
+    other.head = nullptr;
+    other.count = 0;
+    other.foo = nullptr;
+  }
+  return *this;
+}
+
+template <typename T, typename Z>
 void links::SLinkedList<T, Z>::clear() {
   if (this->count > 0) {
     // this->head = nullptr;
@@ -84,23 +202,23 @@ void links::SLinkedList<T, Z>::clear() {
       this->pop();
     }
   }
+  this->head = nullptr;
+  this->count = 0;
 }
 
 template <typename T, typename Z>
 void links::SLinkedList<T, Z>::push(T value) {
   this->count += 1;
-  Node<T> *push = new Node<T>();
+  Node<T> *push = new Node<T>(std::move(value));
   push->next = this->head;
-  push->data = value;
   this->head = push;
 }
 
 template <typename T, typename Z>
 void links::SLinkedList<T, Z>::operator<<(T value) {
   this->count += 1;
-  Node<T> *push = new Node<T>();
+  Node<T> *push = new Node<T>(std::move(value));
   push->next = this->head;
-  push->data = value;
   this->head = push;
 }
 
@@ -126,6 +244,7 @@ T links::SLinkedList<T, Z>::pop() {
   Node<T> *popper = this->head;
   this->head = this->head->next;
   delete popper;
+  if (this->count == 0) head = nullptr;
   return data;
 }
 
@@ -146,6 +265,8 @@ void links::SLinkedList<T, Z>::stitch(SLinkedList<T, Z> l) {
     }
     pointer->next = l.head;
   }
+  l.head = nullptr;
+  l.count = 0;
 }
 
 template <typename T, typename Z>
@@ -161,6 +282,8 @@ void links::SLinkedList<T, Z>::istitch(SLinkedList<T, Z> l) {
     pointer->next = head;
     this->head = l.head;
   }
+  l.head = nullptr;
+  l.count = 0;
 }
 
 #endif

--- a/src/CodeGenerator/Resolver.cpp
+++ b/src/CodeGenerator/Resolver.cpp
@@ -87,14 +87,14 @@ CodeGenerator::resolveSymbol(std::string ident,
     push->op = this->registers["%r14"]->get(asmc::QWord);
     OutputFile.text << push;
     while (modList.trail() > checkTo) {
-      Type type = **this->getType(last.typeName, OutputFile);
+      Type *type = *this->getType(last.typeName, OutputFile);
       std::string sto = modList.touch();
       if (this->scope == *this->typeList[last.typeName]) {
-        modSym =
-            type.SymbolTable.search<std::string>(searchSymbol, modList.shift());
+        modSym = type->SymbolTable.search<std::string>(searchSymbol,
+                                                       modList.shift());
       } else {
-        modSym = type.publicSymbols.search<std::string>(searchSymbol,
-                                                        modList.shift());
+        modSym = type->publicSymbols.search<std::string>(searchSymbol,
+                                                         modList.shift());
       };
       if (modSym == nullptr)
         alert("variable not found " + last.typeName + "." + sto, true, __FILE__,


### PR DESCRIPTION
## Summary
- add iterators and RAII semantics to `LinkedList` and `SLinkedList`
- implement copy/move constructors and assignments
- ensure stitch operations detach their nodes to avoid double free
- fix dangling reference in `resolveSymbol`

## Testing
- `cmake --build build -j $(nproc)`
- `./bin/a.test`

------
https://chatgpt.com/codex/tasks/task_e_6875cb3d662c83288a20f603212f379c