### PR TITLE
Rewrite result as union in stdlib

### DIFF
--- a/libraries/std/src/Utils/result.af
+++ b/libraries/std/src/Utils/result.af
@@ -2,79 +2,51 @@
 
 import string from "String";
 import Error from "Utils/Error";
-import Map from "Utils/Map";
-import Option from "Utils/Option";
 
 types(A)
-safe dynamic pedantic class result {
-    private A value = value;
-    private mutable bool success = error == NULL;
-    private mutable Error error = error;
-    private mutable int refcount = 1;
+union result {
+  Ok(A),
+  Err(Error)
 
-    fn get() -> Self {
-		my.refcount = my.refcount + 1;
-		return my;
-	};
-
-    fn endScope() {
-        my.refcount = my.refcount - 1;
-        if my.refcount == 0 {
-            delete my;
-        };
-        return;
+  safe fn expect() -> A {
+    match my {
+      Ok(value) => return value,
+      Err(err) => {
+        panic(`Error: {err}`.cstr());
+      }
     };
+  };
 
-    fn init(const A value, *const Error error) -> Self {
-        return my;
+  safe fn getError() -> Error {
+    match my {
+      Ok() => return NULL,
+      Err(err) => return err
     };
+  };
 
-    fn expect() -> A {
-        if (!my.success)
-            panic(`Error: {my.error}`.cstr());
-        return my.value;
+  safe fn hasError() -> bool {
+    match my {
+      Ok() => return false,
+      Err() => return true
     };
+  };
 
-    fn getError() -> Error {
-		return my.error;
-	};
-
-	fn hasError() -> bool {
-		return my.success != true;
-	};
-
-    fn toString() -> string {
-        if my.success {
-            return `Ok: {my.value}`;
-        } else {
-            return `Error: {my.error}`;
-        };
+  safe fn toString() -> string {
+    match my {
+      Ok(value) => return `Ok: {value}`,
+      Err(err) => return `Error: {err}`
     };
+  };
 
-    fn match(const Map cases, *const any arg1, *const any arg2, *const any arg3, *const any arg4) -> any {
-		if my.success {
-			if cases.has("ok") {
-				const Option foo = cases.get("ok");
-                const adr foo = foo.orElse(
-                    [] => panic("No case for ok")
-                );
-				return foo(my.value, arg1, arg2, arg3, arg4);
-			} else {
-				panic("No case for ok");
-			};
-		};
-
-		return my.error.match(cases, arg1, arg2, arg3, arg4);
-	};
 
 };
 
 types(T)
-export fn accept(const T value) {
-    return new result::<T>(value);
+export fn accept(const T value) -> result::<T> {
+  return new result::<T>->Ok(value);
 };
 
 types(J)
-export fn reject(const Error error) {
-    return new result::<J>(NULL, error);
+export fn reject(const Error error) -> result::<J> {
+  return new result::<J>->Err(error);
 };


### PR DESCRIPTION
## Summary
- convert the generic `result` type from a class to a union
- drop the custom `match` helper

## Testing
- `bash rebuild-libs.sh` *(fails: `std::length_error`)*
- `make`

------
https://chatgpt.com/codex/tasks/task_e_687790963e4c8328a871235032ded3f1