### PR TITLE
Fix repeated namespace prefix in utils::extract

### DIFF
--- a/src/CodeGenerator/Utils.cpp
+++ b/src/CodeGenerator/Utils.cpp
@@ -106,7 +106,10 @@ ast::Statement *gen::utils::extract(std::string ident, ast::Statement *stmt,
   } else if (dynamic_cast<ast::Function *>(stmt)) {
     ast::Function *func = dynamic_cast<ast::Function *>(stmt);
     if (func->ident.ident == ident || ident == "*") {
-      func->ident.ident = id + '.' + func->ident.ident;
+      std::string prefix = id + '.';
+      if (!prefix.empty() && func->ident.ident.rfind(prefix, 0) != 0) {
+        func->ident.ident = prefix + func->ident.ident;
+      }
       if (func->genericTypes.size() == 0) func->statement = nullptr;
       if (func->scope != ast::Export) func->locked = true;
       return func;


### PR DESCRIPTION
## Summary
- ensure `extract` does not repeatedly prefix function names with the namespace

## Testing
- `make` *(fails: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6877aecc6ffc8328bbfb3ab0731f6172