### PR TITLE
Fix infinite generic class instantiation

### DIFF
--- a/src/CodeGenerator/Resolver.cpp
+++ b/src/CodeGenerator/Resolver.cpp
@@ -29,6 +29,11 @@ Type **CodeGenerator::instantiateGenericClass(
       true;  // we hid the class so all of its functions are private
   Type **result;
   if (this->typeList[newName] == nullptr) {
+    // create a placeholder so recursive instantiation doesn't re-enter
+    gen::Class *placeholder = new gen::Class();
+    placeholder->Ident = newName;
+    this->typeList.push(placeholder);
+
     if (OutputFile.lambdas == nullptr) OutputFile.lambdas = new asmc::File;
     OutputFile.hasLambda = true;
     scope::ScopeManager::getInstance()->pushIsolated();

--- a/src/CodeGenerator/Resolver.cpp
+++ b/src/CodeGenerator/Resolver.cpp
@@ -22,18 +22,22 @@ Type **CodeGenerator::instantiateGenericClass(
     genericMap[classStatement->genericTypes[i]] = types[i];
   }
 
+  bool newlyInserted = false;
+  if (this->typeList[newName] == nullptr) {
+    // insert a placeholder before modifying the AST to stop recursive entry
+    gen::Class *placeholder = new gen::Class();
+    placeholder->Ident = newName;
+    this->typeList.push(placeholder);
+    newlyInserted = true;
+  }
+
   classStatement->replaceTypes(genericMap);
   classStatement->ident.ident = newName;
   classStatement->genericTypes.clear();
   classStatement->hidden =
       true;  // we hid the class so all of its functions are private
   Type **result;
-  if (this->typeList[newName] == nullptr) {
-    // create a placeholder so recursive instantiation doesn't re-enter
-    gen::Class *placeholder = new gen::Class();
-    placeholder->Ident = newName;
-    this->typeList.push(placeholder);
-
+  if (newlyInserted) {
     if (OutputFile.lambdas == nullptr) OutputFile.lambdas = new asmc::File;
     OutputFile.hasLambda = true;
     scope::ScopeManager::getInstance()->pushIsolated();

--- a/src/Parser/AST/Statements/Class.cpp
+++ b/src/Parser/AST/Statements/Class.cpp
@@ -86,8 +86,9 @@ gen::GenerationResult const Class::generate(gen::CodeGenerator &generator) {
   // if the class is generic, do not generate code for it. It will be
   // generated when it is instantiated with specific types.
   if (this->genericTypes.size() > 0) {
+    auto *copy = dynamic_cast<ast::Class *>(ast::deepCopy(this));
     generator.genericTypes.insert(
-        {this->ident.ident, this});  // add the class to the generic types
+        {this->ident.ident, copy});  // add the class to the generic types
     return {asmc::File(), std::nullopt};
   }
 

--- a/src/Parser/AST/Statements/Union.cpp
+++ b/src/Parser/AST/Statements/Union.cpp
@@ -113,8 +113,9 @@ gen::GenerationResult const Union::generate(gen::CodeGenerator &generator) {
   // if the union is generic, do not generate code for it. It will be
   // generated when it is instantiated with specific types.
   if (this->genericTypes.size() > 0) {
+    auto *copy = dynamic_cast<ast::Class *>(ast::deepCopy(this));
     generator.genericTypes.insert(
-        {this->ident.ident, this});  // add the union to the generic types
+        {this->ident.ident, copy});  // add the union to the generic types
     return {asmc::File(), std::nullopt};
   }
 

--- a/src/Parser/DeepCopy.cpp
+++ b/src/Parser/DeepCopy.cpp
@@ -124,11 +124,12 @@ Statement *deepCopy(const Statement *stmt) {
     for (const auto &alias : un->aliases) {
       if (alias.value) {
         if (std::holds_alternative<ast::Type *>(*alias.value)) {
-          copy->aliases.emplace_back(alias.name,
-                                     std::get<ast::Type *>(*alias.value));
+          auto *t = std::get<ast::Type *>(*alias.value);
+          copy->aliases.emplace_back(alias.name, new ast::Type(*t));
         } else if (std::holds_alternative<ast::Expr *>(*alias.value)) {
+          auto *e = std::get<ast::Expr *>(*alias.value);
           copy->aliases.emplace_back(alias.name,
-                                     std::get<ast::Expr *>(*alias.value));
+                                     static_cast<ast::Expr *>(deepCopy(e)));
         } else {
           copy->aliases.emplace_back(alias.name);
         }


### PR DESCRIPTION
## Summary
- prevent recursive instantiation of generic classes by inserting a placeholder entry

## Testing
- `make` *(fails: undefined reference to `vtable for ast::Expr`)*
- `cmake --build build --target a.test` *(fails: interrupted due to build errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877bc2e2be083288a544708a09addd8