### PR TITLE
Add compile-time note statement

### DIFF
--- a/include/Parser/AST/Statements.hpp
+++ b/include/Parser/AST/Statements.hpp
@@ -25,6 +25,7 @@
 #include "Parser/AST/Statements/Import.hpp"
 #include "Parser/AST/Statements/Inc.hpp"
 #include "Parser/AST/Statements/Match.hpp"
+#include "Parser/AST/Statements/Note.hpp"
 #include "Parser/AST/Statements/Return.hpp"
 #include "Parser/AST/Statements/Sequence.hpp"
 #include "Parser/AST/Statements/Struct.hpp"

--- a/include/Parser/AST/Statements/Note.hpp
+++ b/include/Parser/AST/Statements/Note.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include "Parser/AST.hpp"
+
+namespace ast {
+class Note : public Statement {
+ public:
+  std::string message;
+  Note() = default;
+  explicit Note(const std::string &msg) : message(msg) {}
+  gen::GenerationResult const generate(gen::CodeGenerator &generator) override;
+};
+}  // namespace ast

--- a/src/Parser/AST/Statements/Note.cpp
+++ b/src/Parser/AST/Statements/Note.cpp
@@ -1,0 +1,16 @@
+#include "Parser/AST/Statements/Note.hpp"
+
+#include <iostream>
+
+#include "CodeGenerator/CodeGenerator.hpp"
+
+namespace ast {
+
+gen::GenerationResult const Note::generate(gen::CodeGenerator &generator) {
+  std::cout << "Generating: " << message << std::endl;
+  asmc::File file;
+  file.text << new asmc::nop();
+  return {file, std::nullopt};
+}
+
+}  // namespace ast

--- a/src/Parser/DeepCopy.cpp
+++ b/src/Parser/DeepCopy.cpp
@@ -283,6 +283,10 @@ Statement *deepCopy(const Statement *stmt) {
     copy->expr = static_cast<Expr *>(deepCopy(cw->expr));
     return copy;
   }
+  if (auto note = dynamic_cast<const Note *>(stmt)) {
+    auto *copy = new Note(note->message);
+    return copy;
+  }
   if (auto brk = dynamic_cast<const Break *>(stmt)) {
     return new Break(*brk);
   }

--- a/src/Parser/NamespaceSwap.cpp
+++ b/src/Parser/NamespaceSwap.cpp
@@ -45,6 +45,9 @@ void Statement::namespaceSwap(
     if (pull->expr) pull->expr->namespaceSwap(map);
     return;
   }
+  if (auto note = dynamic_cast<Note *>(this)) {
+    return;
+  }
   if (auto buy = dynamic_cast<Buy *>(this)) {
     if (buy->expr) buy->expr->namespaceSwap(map);
     return;

--- a/src/Parser/Parser.cpp
+++ b/src/Parser/Parser.cpp
@@ -563,6 +563,16 @@ ast::Statement *parse::Parser::parseStmt(
       pull->logicalLine = obj.lineCount;
       output = pull;
       if (singleStmt) return output;
+    } else if (obj.meta == "note") {
+      auto expr = this->parseExpr(tokens);
+      auto str = dynamic_cast<ast::StringLiteral *>(expr);
+      if (!str)
+        throw err::Exception("Expected string after note on line " +
+                             std::to_string(obj.lineCount));
+      std::cout << "Parsing: " << str->val << std::endl;
+      auto note = new ast::Note(str->val);
+      note->logicalLine = obj.lineCount;
+      output = note;
     } else if (obj.meta == "if") {
       output = new ast::If(tokens, *this);
     } else if (obj.meta == "while") {

--- a/src/Parser/ReplaceTypes.cpp
+++ b/src/Parser/ReplaceTypes.cpp
@@ -90,6 +90,9 @@ void Statement::replaceTypes(std::unordered_map<std::string, std::string> map) {
     if (pull->expr) pull->expr->replaceTypes(map);
     return;
   }
+  if (auto note = dynamic_cast<Note *>(this)) {
+    return;
+  }
   if (auto buy = dynamic_cast<Buy *>(this)) {
     if (buy->expr) buy->expr->replaceTypes(map);
     return;


### PR DESCRIPTION
## Summary
- introduce `Note` AST statement for compile-time messages
- parse `note` statement and emit messages during parse and codegen
- support deep copy, namespace swap, and type replacement for `Note`
- include new files in build

## Testing
- `cmake --build build --target aflat`
- `cmake --build build --target a.test`
- `./bin/a.test`

------
https://chatgpt.com/codex/tasks/task_e_6879c29005e88328bc7684d7befd43dd