### PR TITLE
Add octal literal parsing

### DIFF
--- a/libraries/std/src/files.af
+++ b/libraries/std/src/files.af
@@ -159,7 +159,7 @@ class File{
 export fn createFile(const adr fileName) -> File! {
         const File file = malloc(File);
         const long flag = #2 | #512 | #64; // O_RDWR | O_CREAT | O_TRUNC
-        file.file = sys_open(fileName, flag, #511);
+        file.file = sys_open(fileName, flag, 0o0777);
         const int test = file.file;
         if(test < 1) {
                 free(file);
@@ -172,7 +172,7 @@ export fn createFile(const adr fileName) -> File! {
 export fn openFile(const adr fileName) -> File! {
         const File file = malloc(File);
         const long flag = #2;
-        file.file = sys_open(fileName, flag, #511);
+        file.file = sys_open(fileName, flag, 0o0777);
         const int test = file.file;
         if(test < 0){
                 free(file);

--- a/src/Parser/Parser.cpp
+++ b/src/Parser/Parser.cpp
@@ -1190,9 +1190,11 @@ ast::Expr *parse::Parser::parseExpr(links::LinkedList<lex::Token *> &tokens) {
     auto intObj = *dynamic_cast<lex::INT *>(tokens.pop());
     auto intLiteral = new ast::IntLiteral();
     intLiteral->logicalLine = intObj.lineCount;
-    // check if the int is a hex
-    if (intObj.value[0] == '0' && intObj.value[1] == 'x') {
+    // check if the int is a hex or octal
+    if (intObj.value.rfind("0x", 0) == 0) {
       intLiteral->val = std::stoi(intObj.value, nullptr, 16);
+    } else if (intObj.value.rfind("0o", 0) == 0) {
+      intLiteral->val = std::stoi(intObj.value.substr(2), nullptr, 8);
     } else {
       intLiteral->val = std::stoi(intObj.value);
     }

--- a/src/Scanner.cpp
+++ b/src/Scanner.cpp
@@ -47,6 +47,16 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
         }
         intLit->lineCount = lineCount;
         tokens << intLit;
+      } else if (input[i] == '0' && input[i + 1] == 'o') {
+        i += 2;
+        auto intLit = new lex::INT();
+        intLit->value = "0o";
+        while (input[i] >= '0' && input[i] <= '7') {
+          intLit->value += input[i];
+          i++;
+        }
+        intLit->lineCount = lineCount;
+        tokens << intLit;
       } else {
         auto IntLit = new lex::INT();
         IntLit->value = input[i];


### PR DESCRIPTION
## Summary
- update scanner to recognize `0o` prefix as octal
- handle octal literals in parser

## Testing
- `make -s -j4` *(fails: interrupt during build)*

------
https://chatgpt.com/codex/tasks/task_e_687b821a53188328bf6e3055686f5140