### PR TITLE
Add shell completion setup to install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Install with one command:
 ```
 curl -s https://raw.githubusercontent.com/DeForestt/aflat/main/install.sh | bash
 ```
+This will automatically add `aflat` to your `PATH` and enable bash/zsh tab completion.
 
 ### Cloning the repository
 ```bash

--- a/completions/aflat.bash
+++ b/completions/aflat.bash
@@ -1,0 +1,17 @@
+_aflat_completion() {
+    local cur prev commands opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    commands="make build run test add file module install update clean"
+    opts="-o --output -c --config -n --name -d --debug -q --quiet -t --trace-alerts -U --update-deps -K --clean-deps -C --clean-cache -N --no-cache -L --lib -h --help"
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        return 0
+    fi
+    if [[ ${COMP_CWORD} -eq 1 ]]; then
+        COMPREPLY=( $(compgen -W "${commands}" -- ${cur}) )
+        return 0
+    fi
+}
+complete -F _aflat_completion aflat

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+install_completion() {
+  local comp_script="$HOME/.aflat/aflat/completions/aflat.bash"
+  if [ -f "$comp_script" ]; then
+    if [ -f "$HOME/.bashrc" ] && ! grep -q "source $comp_script" "$HOME/.bashrc"; then
+      echo "source $comp_script" >> "$HOME/.bashrc"
+    fi
+    if [ -f "$HOME/.zshrc" ] && ! grep -q "source $comp_script" "$HOME/.zshrc"; then
+      echo "source $comp_script" >> "$HOME/.zshrc"
+    fi
+  fi
+}
+
 # Check for git 
 if ! [ -x "$(command -v git)" ]; then
   echo 'Error: git is not installed.' >&2
@@ -35,6 +47,7 @@ if [ -d ~/.aflat ]; then
   (cd ~/.aflat/aflat && cmake -S . -B build -DCMAKE_BUILD_TYPE=Release)
   (cd ~/.aflat/aflat && cmake --build build --target aflat)
   (cd ~/.aflat/aflat && bash rebuild-libs.sh)
+  install_completion
   echo 'aflat updated'
   exit
 fi
@@ -53,5 +66,6 @@ fi
 
 # Build libs
 (cd ~/.aflat/aflat && bash rebuild-libs.sh)
+install_completion
 
 echo 'Done Please restart your terminal or run source ~/.bashrc or source ~/.zshrc'


### PR DESCRIPTION
## Summary
- add a bash completion script for aflat
- automatically source the completion script during install/update
- mention tab completion in README

## Testing
- `make`
- `bash rebuild-libs.sh` *(partial output)*
- `./bin/aflat run` *(fails: missing libs)*

------
https://chatgpt.com/codex/tasks/task_e_687bfcf83de88328b33baf283162d07a