### PR TITLE
Support 'or' in when clause

### DIFF
--- a/include/Parser/AST.hpp
+++ b/include/Parser/AST.hpp
@@ -159,7 +159,7 @@ class Type {
 
   Type() = default;
   Type(const std::string &typeName, const asmc::Size &size)
-      : typeName(typeName), size(size) {};
+      : typeName(typeName), size(size){};
 };
 
 class Arg {

--- a/include/Parser/AST.hpp
+++ b/include/Parser/AST.hpp
@@ -42,12 +42,18 @@ enum class WhenOperator {
   HAS,
 };
 
+enum class WhenJoiner {
+  AND,
+  OR,
+};
+
 class WhenPredicat {
  public:
   bool negated = false;
   WhenOperator op;
   std::string typeName;
   std::string ident;
+  WhenJoiner join = WhenJoiner::AND;  // relation to next predicate
 };
 
 class When {
@@ -153,7 +159,7 @@ class Type {
 
   Type() = default;
   Type(const std::string &typeName, const asmc::Size &size)
-      : typeName(typeName), size(size){};
+      : typeName(typeName), size(size) {};
 };
 
 class Arg {

--- a/libraries/std/src/Collections/Vector.af
+++ b/libraries/std/src/Collections/Vector.af
@@ -69,6 +69,7 @@ class vector {
         return my.get(my.count - 1);
     };
 
+    when (T is primitive and T is not adr)
     fn pop_back() -> option::<T> {
         if my.count == 0 {
             return opt.None::<T>();
@@ -76,7 +77,17 @@ class vector {
 
         my.count = my.count - 1;
         const T val = my.head + (my.count * T);
-        return opt.Some::<T>(val);
+        return opt.Some::<T>(val as T);
+    };
+
+    when (T is not primitive or T is adr)
+    fn pop_back() -> option::<T> {
+        if my.count == 0 {
+            return opt.None::<T>();
+        };
+        my.count = my.count - 1;
+        const T val = my.head + (my.count * T);
+        return opt.Some(val);
     };
 
     when (T is primitive and T is not adr)

--- a/libraries/std/src/Collections/Vector.af
+++ b/libraries/std/src/Collections/Vector.af
@@ -37,19 +37,7 @@ class vector {
         return my;
     };
 
-    when (T is not primitive)
-    fn push_back(const T &&value) -> Self {
-        if my.count == my.size {
-            my.size = my.size * 2;
-            my.head = realloc(my.head, T * my.size);
-        };
-
-        memcpy(my.head + (my.count * T), value, T);
-        my.count = my.count + 1;
-        return my;
-    };
-
-    when (T is adr)
+    when (T is not primitive or T is adr)
     fn push_back(const T &&value) -> Self {
         if my.count == my.size {
             my.size = my.size * 2;
@@ -100,16 +88,7 @@ class vector {
         return opt.Some(val as T);
     };
 
-    when (T is adr)
-    fn get(const int index) -> option::<T> {
-        if index >= my.count | index < 0 {
-            return opt.None::<T>();
-        };
-        const T val = my.head + (index * T);
-        return opt.Some(val);
-    };
-
-    when (T is not primitive)
+    when (T is adr or T is not primitive)
     fn get(const int index) -> option::<T> {
         if index >= my.count | index < 0 {
             return opt.None::<T>();
@@ -134,7 +113,7 @@ class vector {
         };
     };
 
-    when (T is not primitive)
+    when (T is not primitive or T is adr)
     fn set(const int index, const T &&value) -> result::<bool> {
         if index >= my.count {
             return res.reject::<bool>(new Error("Index out of bounds"));
@@ -151,15 +130,6 @@ class vector {
         memcpy(my.head + (index * T), ?value, T);
         return res.accept(true);
     };
-
-    when (T is adr)
-    fn set(const int index, const T &&value) -> result::<bool> {
-        if index >= my.count {
-            return res.reject::<bool>(new Error("Index out of bounds"));
-        };
-        memcpy(my.head + (index * T), value, T);
-        return res.accept(true);
-    };  
 
     fn next() -> option::<T> {
         const let val = my.get(my.iteratorIndex);

--- a/src/Parser/Parser.cpp
+++ b/src/Parser/Parser.cpp
@@ -1176,21 +1176,23 @@ ast::When parse::Parser::parseWhenClause(
                            std::to_string(lineCount));
     }
 
-    when.predicates.push_back(pred);
-
     auto close = dynamic_cast<lex::OpSym *>(tokens.peek());
     if (close && close->Sym == ')') {
       tokens.pop();
+      when.predicates.push_back(pred);
       break;
     }
 
-    auto andTok = dynamic_cast<lex::LObj *>(tokens.peek());
-    if (andTok && andTok->meta == "and") {
+    auto joinTok = dynamic_cast<lex::LObj *>(tokens.peek());
+    if (joinTok && (joinTok->meta == "and" || joinTok->meta == "or")) {
       tokens.pop();
+      pred.join =
+          (joinTok->meta == "and") ? ast::WhenJoiner::AND : ast::WhenJoiner::OR;
+      when.predicates.push_back(pred);
       continue;
     }
 
-    throw err::Exception("Expected 'and' or ')' in when clause on line " +
+    throw err::Exception("Expected 'and', 'or' or ')' in when clause on line " +
                          std::to_string(lineCount));
   }
 


### PR DESCRIPTION
## Summary
- extend `WhenPredicat` with a `WhenJoiner` enum
- allow `or` as a separator in `parseWhenClause`
- evaluate `WhenJoiner` in `whenSatisfied`
- update tests for `or` semantics

## Testing
- `cmake --build build -j$(nproc)`
- `./bin/a.test`

------
https://chatgpt.com/codex/tasks/task_e_6885aebb89ec8328aa779043ca5de9a4