### PR TITLE
Implement ellipsis no-op statement

### DIFF
--- a/include/Parser/AST/Statements.hpp
+++ b/include/Parser/AST/Statements.hpp
@@ -18,6 +18,7 @@
 #include "Parser/AST/Statements/Declare.hpp"
 #include "Parser/AST/Statements/Delete.hpp"
 #include "Parser/AST/Statements/Destructure.hpp"
+#include "Parser/AST/Statements/Ellipsis.hpp"
 #include "Parser/AST/Statements/Enum.hpp"
 #include "Parser/AST/Statements/For.hpp"
 #include "Parser/AST/Statements/ForEach.hpp"

--- a/include/Parser/AST/Statements/Ellipsis.hpp
+++ b/include/Parser/AST/Statements/Ellipsis.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include "Parser/AST.hpp"
+
+namespace ast {
+class Ellipsis : public Statement {
+ public:
+  Ellipsis() = default;
+  gen::GenerationResult const generate(gen::CodeGenerator &generator) override;
+};
+}  // namespace ast

--- a/src/Parser/AST/Statements/Ellipsis.cpp
+++ b/src/Parser/AST/Statements/Ellipsis.cpp
@@ -1,0 +1,13 @@
+#include "Parser/AST/Statements/Ellipsis.hpp"
+
+#include "CodeGenerator/CodeGenerator.hpp"
+
+namespace ast {
+
+gen::GenerationResult const Ellipsis::generate(gen::CodeGenerator &generator) {
+  asmc::File file;
+  file.text << new asmc::nop();
+  return {file, std::nullopt};
+}
+
+}  // namespace ast

--- a/src/Parser/Parser.cpp
+++ b/src/Parser/Parser.cpp
@@ -143,6 +143,21 @@ ast::Statement *parse::Parser::parseStmt(
     atSym = dynamic_cast<lex::OpSym *>(tokens.peek());
   }
 
+  // ellipsis statement ...
+  auto dot = dynamic_cast<lex::OpSym *>(tokens.peek());
+  if (dot && dot->Sym == '.' && tokens.size() >= 3) {
+    auto dot2 = dynamic_cast<lex::OpSym *>(tokens.get(1));
+    auto dot3 = dynamic_cast<lex::OpSym *>(tokens.get(2));
+    if (dot2 && dot2->Sym == '.' && dot3 && dot3->Sym == '.') {
+      tokens.pop();
+      tokens.pop();
+      tokens.pop();
+      auto ellipsis = new ast::Ellipsis();
+      ellipsis->logicalLine = dot->lineCount;
+      output = ellipsis;
+    }
+  }
+
   if (dynamic_cast<lex::LObj *>(tokens.peek()) != nullptr) {
     auto obj = *dynamic_cast<lex::LObj *>(tokens.peek());
     auto safeType = false;

--- a/test/test_Ellipsis.cpp
+++ b/test/test_Ellipsis.cpp
@@ -1,0 +1,15 @@
+#include "Parser/Parser.hpp"
+#include "Scanner.hpp"
+#include "catch.hpp"
+
+TEST_CASE("Parser handles ellipsis as a no-op statement", "[parser]") {
+  lex::Lexer l;
+  auto tokens = l.Scan("...;");
+  tokens.invert();
+  parse::Parser p;
+  ast::Statement *stmt = p.parseStmt(tokens);
+  auto *seq = dynamic_cast<ast::Sequence *>(stmt);
+  REQUIRE(seq != nullptr);
+  auto *ellipsis = dynamic_cast<ast::Ellipsis *>(seq->Statement1);
+  REQUIRE(ellipsis != nullptr);
+}


### PR DESCRIPTION
## Summary
- add `Ellipsis` statement that generates a `nop`
- parse `...` as an `Ellipsis` no-op statement
- test parsing of ellipsis

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `./bin/a.test`

------
https://chatgpt.com/codex/tasks/task_e_6886c02f6cf48328a164579c43e08196