### PR TITLE
Fix generic import dependencies

### DIFF
--- a/src/CodeGenerator/Statements.cpp
+++ b/src/CodeGenerator/Statements.cpp
@@ -221,15 +221,10 @@ asmc::File gen::CodeGenerator::ImportsOnly(ast::Statement *STMT) {
     this->ImportsOnly(dynamic_cast<ast::Sequence *>(STMT)->Statement2);
   } else if (dynamic_cast<ast::Import *>(STMT) != nullptr) {
     auto imp = dynamic_cast<ast::Import *>(STMT);
-    if (imp->hasClasses) {
-      auto prev = this->cwd;
-      if (!imp->cwd.empty()) this->cwd = imp->cwd;
-      if (imp->hasFunctions)
-        imp->generateClasses(*this);
-      else
-        imp->generate(*this);
-      this->cwd = prev;
-    }
+    auto prev = this->cwd;
+    if (!imp->cwd.empty()) this->cwd = imp->cwd;
+    imp->generate(*this);
+    this->cwd = prev;
   }
   return OutputFile;
 }

--- a/test/test_Import.cpp
+++ b/test/test_Import.cpp
@@ -30,7 +30,7 @@ TEST_CASE("Parser handles mixed import of classes and functions", "[parser]") {
   REQUIRE(imp->imports[1] == "bar");
 }
 
-TEST_CASE("ImportsOnly ignores functions in mixed import", "[codegen]") {
+TEST_CASE("ImportsOnly includes functions in mixed import", "[codegen]") {
   std::ofstream mod("Temp.af");
   mod << "class Foo {}\n";
   mod << "export int bar() { return 0; };\n";
@@ -54,8 +54,7 @@ TEST_CASE("ImportsOnly ignores functions in mixed import", "[codegen]") {
   gen.ImportsOnly(imp);
 
   REQUIRE(gen.includedClasses.contains("Temp::Foo"));
-  REQUIRE_FALSE(gen.includedClasses.contains("Temp::bar"));
-  REQUIRE_FALSE(gen.nameSpaceTable.contains("m"));
+  REQUIRE(gen.nameSpaceTable.contains("m"));
 
   std::remove("Temp.af");
 }


### PR DESCRIPTION
## Summary
- run all imports when processing dependencies
- update tests for generic imports

## Testing
- `cmake --build build -j4`
- `./bin/a.test`

------
https://chatgpt.com/codex/tasks/task_e_688706731f9883288337ff1adf9c6b03