### PR TITLE
Update docs for aflat.cfg

### DIFF
--- a/Docs.md
+++ b/Docs.md
@@ -1156,7 +1156,37 @@ The package manager is used to create a project.  The syntax is:
 aflat make <project name>
 ```
 Add `--lib` before `make` to generate a library template without a `main` file.
-The project name is will be the name of the directory that will be created. It will create a head, src, and bin directory.  The head directory will contain the header files for the project.  The src directory will contain the source files for the project.  The bin directory will contain the compiled object files for the project.  It will also create an `aflat.cfg` file using an INI format for build settings and dependencies.
+The project name will be the name of the directory that is created. It will
+include `head`, `src`, and `bin` folders for headers, source files, and build
+artifacts. It also creates an `aflat.cfg` file using an INI format for build
+settings and dependencies.
+
+### The `aflat.cfg` file
+`aflat.cfg` contains a `[build]` section describing how the project is compiled
+and an optional `[dependencies]` section for additional modules. A typical
+configuration looks like:
+
+```ini
+[build]
+main = main         ; entry source relative to src/
+test = test/test    ; path to test file
+output = ./bin/app  ; output binary path
+debug = true        ; enable debug symbols
+asm = true          ; emit assembly
+```
+
+Entries under `[dependencies]` can point to local modules or git repositories.
+For example:
+
+```ini
+[dependencies]
+collections = "./src/collections.af"     ; local file
+logger = "https://github.com/example/logger.git" ; git repo
+```
+
+Use `aflat install <repo>` to add a git dependency and update `aflat.cfg`
+automatically. Run `aflat -U` to refresh all dependencies or `aflat -K` to
+remove them.
 
 ## Building a Project
 The project can be built with the following syntax:

--- a/README.md
+++ b/README.md
@@ -66,9 +66,23 @@ int main(){
 ```
 
 ### Building a project
-The aflat `make` command will have generated an `aflat.cfg` configuration file that tells the built in pacage manager what to build and link the file.
+The `aflat make` command generates an `aflat.cfg` file that describes how the
+package manager should build your project. The configuration uses an INI style
+format with a `[build]` section for settings like the entry point and output
+binary as well as an optional `[dependencies]` section for additional modules.
 ```bash
 aflat build
+```
+
+### Including dependencies
+Add modules under `[dependencies]` in `aflat.cfg`. Each entry can be a relative
+path to a `.af` file or a Git repository URL. Use `aflat install <repo>` to clone
+a Git dependency and automatically update the configuration. Example:
+
+```ini
+[dependencies]
+collections = "./src/collections.af"
+logger = "https://github.com/example/logger.git"
 ```
 
 ### Running the project

--- a/first-steps.MD
+++ b/first-steps.MD
@@ -27,7 +27,20 @@ aflat make tutorial
 ```
 Use `--lib` before `make` if you want a library project instead of an executable.
 
-The tutorial project will have been created in the `tutorial` directory.  The tutorial project will have a `aflat.cfg` file that will tell the aflat build system what to build and link.  The tutorial project will have a `src/main.af` file that will be the entry point for the project. It will also have a `src/test/test.af` file that is will be used to test the project with the `aflat test` command.
+The tutorial project will be created in the `tutorial` directory.  It includes
+an `aflat.cfg` file that tells the build system what to compile and link.  The
+project also contains a `src/main.af` entry point and a `src/test/test.af` file
+used by the `aflat test` command.
+
+### Adding dependencies
+List additional modules under `[dependencies]` in `aflat.cfg`. For external
+repositories run:
+
+```bash
+aflat install <git_repo>
+```
+
+This clones the repository and updates the configuration automatically.
 
 Open up the `main.af` file in your favorite text editor.  The file will look something like this:
 ```js


### PR DESCRIPTION
## Summary
- clarify purpose of `aflat.cfg` in README
- fix tutorial wording around `aflat.cfg`
- document configuration format in Docs
- explain how to add dependencies

## Testing
- `make`
- `./bin/aflat run` *(fails: missing standard library .s files)*


------
https://chatgpt.com/codex/tasks/task_e_688852b971ec8328a2c859f326205a62