### PR TITLE
Support generics in union aliases

### DIFF
--- a/test/test_UnionAliasGeneric.cpp
+++ b/test/test_UnionAliasGeneric.cpp
@@ -1,0 +1,38 @@
+#include <filesystem>
+#include <fstream>
+
+#include "Configs.hpp"
+#include "catch.hpp"
+
+bool build(std::string path, std::string output, cfg::Mutability mutability,
+           bool debug);
+
+TEST_CASE("generic type in union alias", "[union][generics]") {
+  namespace fs = std::filesystem;
+  fs::create_directories("tmp");
+  std::ofstream ofs("tmp/ualias.af");
+  ofs << ".needs <std>\n";
+  ofs << "types(U)\n";
+  ofs << "class Box {\n";
+  ofs << "    U value = value;\n";
+  ofs << "    fn init(U value) -> Self { return my; };\n";
+  ofs << "};\n";
+  ofs << "types(T)\n";
+  ofs << "union Wrapper { Boxed(Box::<T>), Num(int) };\n";
+  ofs << "types(T)\n";
+  ofs << "fn makeBox(T v) -> Wrapper::<T> { return new "
+         "Wrapper::<T>->Boxed(Box::<T>(v)); };\n";
+  ofs << "fn main() -> int {\n";
+  ofs << "    let w = makeBox::<int>(5);\n";
+  ofs << "    return 0;\n";
+  ofs << "};\n";
+  ofs.close();
+
+  bool result =
+      build("tmp/ualias.af", "tmp/ualias.s", cfg::Mutability::Strict, false);
+  if (fs::exists("tmp/ualias.af")) fs::remove("tmp/ualias.af");
+  if (fs::exists("tmp/ualias.s")) fs::remove("tmp/ualias.s");
+  fs::remove("tmp");
+
+  REQUIRE(result);
+}


### PR DESCRIPTION
## Summary
- allow generic types in union alias definitions
- propagate template substitutions inside unions
- add regression test for using a generic type in a union alias

## Testing
- `cmake --build . > /tmp/build.log 2>&1 && tail -n 20 /tmp/build.log`
- `../bin/a.test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68885adf42e48328b39ec7ec9d42db6a