### PR TITLE
Implement rule-of-six for container classes

### DIFF
--- a/include/HashMap.hpp
+++ b/include/HashMap.hpp
@@ -5,6 +5,11 @@
 template <typename Z> class HashMap {
 public:
   HashMap();
+  ~HashMap();
+  HashMap(const HashMap &other);
+  HashMap &operator=(const HashMap &other);
+  HashMap(HashMap &&other) noexcept;
+  HashMap &operator=(HashMap &&other) noexcept;
   void insert(std::string key, Z value);
   Z get(std::string key);
   void remove(std::string key);
@@ -31,6 +36,85 @@ template <typename Z> HashMap<Z>::HashMap() {
   for (int i = 0; i < this->tableSize; i++) {
     this->table[i] = nullptr;
   }
+}
+
+template <typename Z> HashMap<Z>::~HashMap() {
+  clear();
+  delete[] this->table;
+  this->table = nullptr;
+  this->tableSize = 0;
+}
+
+template <typename Z> HashMap<Z>::HashMap(const HashMap &other) : HashMap() {
+  delete[] this->table;
+  this->tableSize = other.tableSize;
+  this->table = new Node *[this->tableSize];
+  for (int i = 0; i < this->tableSize; ++i)
+    this->table[i] = nullptr;
+  for (int i = 0; i < other.tableSize; ++i) {
+    Node *curr = other.table[i];
+    Node **tail = &this->table[i];
+    while (curr != nullptr) {
+      Node *newNode = new Node();
+      newNode->key = curr->key;
+      newNode->value = curr->value;
+      newNode->next = nullptr;
+      *tail = newNode;
+      tail = &newNode->next;
+      curr = curr->next;
+    }
+  }
+  this->count = other.count;
+}
+
+template <typename Z> HashMap<Z> &HashMap<Z>::operator=(const HashMap &other) {
+  if (this != &other) {
+    clear();
+    delete[] this->table;
+    this->tableSize = other.tableSize;
+    this->table = new Node *[this->tableSize];
+    for (int i = 0; i < this->tableSize; ++i)
+      this->table[i] = nullptr;
+    for (int i = 0; i < other.tableSize; ++i) {
+      Node *curr = other.table[i];
+      Node **tail = &this->table[i];
+      while (curr != nullptr) {
+        Node *newNode = new Node();
+        newNode->key = curr->key;
+        newNode->value = curr->value;
+        newNode->next = nullptr;
+        *tail = newNode;
+        tail = &newNode->next;
+        curr = curr->next;
+      }
+    }
+    this->count = other.count;
+  }
+  return *this;
+}
+
+template <typename Z> HashMap<Z>::HashMap(HashMap &&other) noexcept {
+  this->table = other.table;
+  this->tableSize = other.tableSize;
+  this->count = other.count;
+  other.table = nullptr;
+  other.tableSize = 0;
+  other.count = 0;
+}
+
+template <typename Z>
+HashMap<Z> &HashMap<Z>::operator=(HashMap &&other) noexcept {
+  if (this != &other) {
+    clear();
+    delete[] this->table;
+    this->table = other.table;
+    this->tableSize = other.tableSize;
+    this->count = other.count;
+    other.table = nullptr;
+    other.tableSize = 0;
+    other.count = 0;
+  }
+  return *this;
 }
 
 template <typename Z> void HashMap<Z>::insert(std::string key, Z value) {
@@ -84,6 +168,8 @@ template <typename Z> void HashMap<Z>::remove(std::string key) {
 }
 
 template <typename Z> void HashMap<Z>::clear() {
+  if (!this->table)
+    return;
   for (int i = 0; i < this->tableSize; i++) {
     Node *curr = this->table[i];
     while (curr != nullptr) {
@@ -91,6 +177,7 @@ template <typename Z> void HashMap<Z>::clear() {
       curr = curr->next;
       delete temp;
     }
+    this->table[i] = nullptr;
   }
   this->count = 0;
 }

--- a/include/LinkedListS.hpp
+++ b/include/LinkedListS.hpp
@@ -155,8 +155,14 @@ template <typename T, typename Z> links::SLinkedList<T, Z>::~SLinkedList() {
 template <typename T, typename Z>
 links::SLinkedList<T, Z>::SLinkedList(const SLinkedList &other)
     : SLinkedList() {
-  for (const auto &v : other)
-    push(v);
+  foo = other.foo;
+  Node<T> **tail = &head;
+  for (const auto &v : other) {
+    Node<T> *n = new Node<T>(v);
+    *tail = n;
+    tail = &n->next;
+    ++count;
+  }
 }
 
 template <typename T, typename Z>
@@ -164,8 +170,14 @@ links::SLinkedList<T, Z> &
 links::SLinkedList<T, Z>::operator=(const SLinkedList &other) {
   if (this != &other) {
     clear();
-    for (const auto &v : other)
-      push(v);
+    foo = other.foo;
+    Node<T> **tail = &head;
+    for (const auto &v : other) {
+      Node<T> *n = new Node<T>(v);
+      *tail = n;
+      tail = &n->next;
+      ++count;
+    }
   }
   return *this;
 }

--- a/test/test_HashMap.cpp
+++ b/test/test_HashMap.cpp
@@ -12,3 +12,29 @@ TEST_CASE("HashMap insert and retrieve", "[hashmap]") {
   REQUIRE(map.size() == 0);
   REQUIRE_FALSE(map.contains("a"));
 }
+
+TEST_CASE("HashMap copy and move", "[hashmap]") {
+  HashMap<int *> map;
+  int a = 1, b = 2;
+  map.insert("a", &a);
+  map.insert("b", &b);
+
+  HashMap<int *> copy(map);
+  REQUIRE(copy.size() == map.size());
+  REQUIRE(*(copy.get("a")) == 1);
+  REQUIRE(*(copy.get("b")) == 2);
+
+  HashMap<int *> assigned;
+  assigned = map;
+  REQUIRE(assigned.size() == map.size());
+  REQUIRE(*(assigned.get("a")) == 1);
+
+  HashMap<int *> moved(std::move(map));
+  REQUIRE(moved.size() == 2);
+  REQUIRE(map.size() == 0);
+
+  HashMap<int *> moveAssigned;
+  moveAssigned = std::move(moved);
+  REQUIRE(moveAssigned.size() == 2);
+  REQUIRE(moved.size() == 0);
+}

--- a/test/test_LinkedList.cpp
+++ b/test/test_LinkedList.cpp
@@ -18,3 +18,27 @@ TEST_CASE("LinkedList invert", "[linkedlist]") {
   list.invert();
   REQUIRE(list.peek() == 1);
 }
+
+TEST_CASE("LinkedList copy and move", "[linkedlist]") {
+  links::LinkedList<int> list;
+  list.push(1);
+  list.push(2);
+
+  links::LinkedList<int> copy(list);
+  REQUIRE(copy.size() == list.size());
+  REQUIRE(copy.peek() == list.peek());
+
+  links::LinkedList<int> assigned;
+  assigned = list;
+  REQUIRE(assigned.size() == list.size());
+  REQUIRE(assigned.peek() == list.peek());
+
+  links::LinkedList<int> moved(std::move(list));
+  REQUIRE(moved.size() == 2);
+  REQUIRE(list.size() == 0);
+
+  links::LinkedList<int> moveAssigned;
+  moveAssigned = std::move(moved);
+  REQUIRE(moveAssigned.size() == 2);
+  REQUIRE(moved.size() == 0);
+}

--- a/test/test_SLinkedList.cpp
+++ b/test/test_SLinkedList.cpp
@@ -13,3 +13,28 @@ TEST_CASE("SLinkedList basic operations", "[slinkedlist]") {
   REQUIRE(list.count == 1);
   REQUIRE(*(list[1]) == 1);
 }
+
+TEST_CASE("SLinkedList copy and move", "[slinkedlist]") {
+  links::SLinkedList<int, int> list;
+  list.foo = comp;
+  list.push(1);
+  list.push(2);
+
+  links::SLinkedList<int, int> copy(list);
+  REQUIRE(copy.count == list.count);
+  REQUIRE(copy.peek() == list.peek());
+
+  links::SLinkedList<int, int> assigned;
+  assigned = list;
+  REQUIRE(assigned.count == list.count);
+  REQUIRE(assigned.peek() == list.peek());
+
+  links::SLinkedList<int, int> moved(std::move(list));
+  REQUIRE(moved.count == 2);
+  REQUIRE(list.count == 0);
+
+  links::SLinkedList<int, int> moveAssigned;
+  moveAssigned = std::move(moved);
+  REQUIRE(moveAssigned.count == 2);
+  REQUIRE(moved.count == 0);
+}


### PR DESCRIPTION
## Summary
- Complete rule-of-six special members for `HashMap` and fix `SLinkedList` copying logic
- Add copy/move unit tests for LinkedList, SLinkedList, and HashMap

## Testing
- `make`
- `g++ -std=c++17 -O3 -I include -I test test/test.cpp test/test_LinkedList.cpp test/test_SLinkedList.cpp test/test_HashMap.cpp -o test/test_runner -pthread && ./test/test_runner`

------
https://chatgpt.com/codex/tasks/task_e_68adf8abdf2c8328803f962b24af7ec6