### PR TITLE
Use shared_ptr tokens in scanner

### DIFF
--- a/include/Scanner.hpp
+++ b/include/Scanner.hpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "LinkedList.hpp"
+#include <memory>
 
 using links::LinkedList;
 using std::string;
@@ -104,8 +105,18 @@ public:
 that the parser will be able to understand*/
 class Lexer {
 public:
-  LinkedList<Token *> Scan(string input, int startLine = 1);
+  LinkedList<std::shared_ptr<Token>> Scan(string input, int startLine = 1);
 };
+
+template <typename T>
+links::LinkedList<T *>
+toRawList(const links::LinkedList<std::shared_ptr<T>> &list) {
+  links::LinkedList<T *> out;
+  for (const auto &ptr : list) {
+    out << ptr.get();
+  }
+  return out;
+}
 
 }; // namespace lex
 #endif

--- a/src/Parser/AST/Statements/Import.cpp
+++ b/src/Parser/AST/Statements/Import.cpp
@@ -174,9 +174,10 @@ gen::GenerationResult const Import::generate(gen::CodeGenerator &generator) {
     lex::Lexer l = lex::Lexer();
     PreProcessor pp = PreProcessor();
 
-    auto tokens = l.Scan(pp.PreProcess(text, gen::utils::getLibPath("head"),
-                                       generator.cwd.string()));
-    tokens.invert();
+    auto tokenPtrs = l.Scan(pp.PreProcess(text, gen::utils::getLibPath("head"),
+                                          generator.cwd.string()));
+    tokenPtrs.invert();
+    auto tokens = lex::toRawList(tokenPtrs);
     // parse the file
     parse::Parser p = parse::Parser();
     ast::Statement *statement = p.parseStmt(tokens);
@@ -249,9 +250,10 @@ Import::generateClasses(gen::CodeGenerator &generator) {
     lex::Lexer l = lex::Lexer();
     PreProcessor pp = PreProcessor();
 
-    auto tokens = l.Scan(pp.PreProcess(text, gen::utils::getLibPath("head"),
-                                       generator.cwd.string()));
-    tokens.invert();
+    auto tokenPtrs = l.Scan(pp.PreProcess(text, gen::utils::getLibPath("head"),
+                                          generator.cwd.string()));
+    tokenPtrs.invert();
+    auto tokens = lex::toRawList(tokenPtrs);
     parse::Parser p = parse::Parser();
     if (this->path.find("./") != std::string::npos)
       p.mutability = generator.mutability;

--- a/src/Parser/AST/Statements/Transform.cpp
+++ b/src/Parser/AST/Statements/Transform.cpp
@@ -73,8 +73,10 @@ Transform::parse(const std::string &ident, std::string &type, std::string &expr,
   lex::Lexer l = lex::Lexer();
   PreProcessor pp = PreProcessor();
 
-  auto tokens = l.Scan(pp.PreProcess(result, gen::utils::getLibPath("head")));
-  tokens.invert();
+  auto tokenPtrs =
+      l.Scan(pp.PreProcess(result, gen::utils::getLibPath("head")));
+  tokenPtrs.invert();
+  auto tokens = lex::toRawList(tokenPtrs);
   // parse the file
   ast::Statement *statement = generator.parser.parseStmt(tokens);
   auto Lowerer = parse::lower::Lowerer(statement, true);

--- a/src/Parser/Parser.cpp
+++ b/src/Parser/Parser.cpp
@@ -1361,8 +1361,9 @@ ast::Expr *parse::Parser::parseExpr(links::LinkedList<lex::Token *> &tokens) {
       int startLine =
           fstringObj.lineCount +
           std::count(original.begin(), original.begin() + pos + offset, '\n');
-      auto tokes = lexer.Scan(expr, startLine);
-      tokes.invert();
+      auto tokesPtrs = lexer.Scan(expr, startLine);
+      tokesPtrs.invert();
+      auto tokes = lex::toRawList(tokesPtrs);
       auto exprAst = this->parseExpr(tokes);
       fstringLiteral->args.push_back(exprAst);
 

--- a/src/Scanner.cpp
+++ b/src/Scanner.cpp
@@ -3,18 +3,21 @@
 #include <ctype.h>
 
 #include <iostream>
+#include <memory>
 
 #include "Exceptions.hpp"
 
-LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
-  LinkedList<lex::Token *> tokens = LinkedList<lex::Token *>();
+LinkedList<std::shared_ptr<lex::Token>> lex::Lexer::Scan(string input,
+                                                         int startLine) {
+  LinkedList<std::shared_ptr<lex::Token>> tokens =
+      LinkedList<std::shared_ptr<lex::Token>>();
   int i = 0;
   int lineCount = startLine;
   while (i < input.length()) {
     if (input[i] == '\n')
       lineCount++;
     if (std::isalpha(input[i]) || input[i] == '_') {
-      auto l_obj = new LObj();
+      auto l_obj = std::make_shared<LObj>();
       l_obj->meta = "";
       while (std::isalpha(input[i]) || std::isdigit(input[i]) ||
              input[i] == '_') {
@@ -26,13 +29,13 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
     } else if (std::isdigit(input[i]) || input[i] == '-') {
       if (input[i] == '-' && !std::isdigit(input[i + 1])) {
         if (input[i + 1] == '>') {
-          auto sym = new lex::Symbol;
+          auto sym = std::make_shared<lex::Symbol>();
           sym->meta = "->";
           i += 2;
           sym->lineCount = lineCount;
           tokens << sym;
         } else {
-          auto sym = new lex::OpSym;
+          auto sym = std::make_shared<lex::OpSym>();
           sym->Sym = '-';
           i++;
           sym->lineCount = lineCount;
@@ -40,7 +43,7 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
         }
       } else if (input[i] == '0' && input[i + 1] == 'x') {
         i += 2;
-        auto intLit = new lex::INT();
+        auto intLit = std::make_shared<lex::INT>();
         intLit->value = "0x";
         while (std::isxdigit(input[i])) {
           intLit->value += input[i];
@@ -50,7 +53,7 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
         tokens << intLit;
       } else if (input[i] == '0' && input[i + 1] == 'o') {
         i += 2;
-        auto intLit = new lex::INT();
+        auto intLit = std::make_shared<lex::INT>();
         intLit->value = "0o";
         while (input[i] >= '0' && input[i] <= '7') {
           intLit->value += input[i];
@@ -59,7 +62,7 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
         intLit->lineCount = lineCount;
         tokens << intLit;
       } else {
-        auto IntLit = new lex::INT();
+        auto IntLit = std::make_shared<lex::INT>();
         IntLit->value = input[i];
         i++;
 
@@ -77,7 +80,7 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
                                  " on line " + std::to_string(lineCount));
           }
 
-          auto FloatLit = new lex::FloatLit();
+          auto FloatLit = std::make_shared<lex::FloatLit>();
           FloatLit->value = IntLit->value;
           FloatLit->lineCount = lineCount;
           tokens << FloatLit;
@@ -85,7 +88,7 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
           tokens << IntLit;
       }
     } else if (input[i] == '#') {
-      auto *IntLit = new lex::Long();
+      auto IntLit = std::make_shared<lex::Long>();
       i++;
 
       while (std::isdigit(input[i])) {
@@ -97,7 +100,7 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
     } else if (std::isspace(input[i])) {
       i++;
     } else if (input[i] == '\"') {
-      auto *stringObj = new StringObj();
+      auto stringObj = std::make_shared<StringObj>();
       stringObj->value = "";
       i++;
       while (input[i] != '\"') {
@@ -136,7 +139,7 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
       stringObj->lineCount = lineCount;
       tokens.push(stringObj);
     } else if (input[i] == '`') {
-      auto *stringObj = new FStringObj();
+      auto stringObj = std::make_shared<FStringObj>();
       stringObj->value = "";
       i++;
       while (input[i] != '`') {
@@ -175,7 +178,7 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
       stringObj->lineCount = lineCount;
       tokens.push(stringObj);
     } else if (input[i] == '~') {
-      auto *stringObj = new lex::StringObj();
+      auto stringObj = std::make_shared<lex::StringObj>();
       stringObj->value = "";
       i++;
       while (input[i] != '~') {
@@ -190,7 +193,7 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
       stringObj->lineCount = lineCount;
       tokens.push(stringObj);
     } else if (input[i] == '\'') {
-      auto charobj = new CharObj();
+      auto charobj = std::make_shared<CharObj>();
       i++;
       if (input[i] == '\\') {
         i++;
@@ -223,63 +226,63 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
       tokens << charobj;
       i++;
     } else if (input[i] == ';') {
-      auto semi = new OpSym;
+      auto semi = std::make_shared<OpSym>();
       semi->Sym = input[i];
       semi->lineCount = lineCount;
       tokens.push(semi);
       i++;
     } else if (input[i] == '?') {
-      auto Ref = new lex::Ref;
+      auto Ref = std::make_shared<lex::Ref>();
       Ref->lineCount = lineCount;
       tokens << Ref;
       i++;
     } else if (input[i] == '(') {
-      auto cPrenth = new OpSym;
+      auto cPrenth = std::make_shared<OpSym>();
       cPrenth->Sym = input[i];
       cPrenth->lineCount = lineCount;
       tokens.push(cPrenth);
       i++;
     } else if (input[i] == ')') {
-      auto cPrenth = new OpSym;
+      auto cPrenth = std::make_shared<OpSym>();
       cPrenth->Sym = input[i];
       cPrenth->lineCount = lineCount;
       tokens.push(cPrenth);
       i++;
     } else if (input[i] == '{') {
-      auto cPrenth = new OpSym;
+      auto cPrenth = std::make_shared<OpSym>();
       cPrenth->Sym = input[i];
       cPrenth->lineCount = lineCount;
       tokens.push(cPrenth);
       i++;
     } else if (input[i] == '}') {
-      lex::OpSym *cPrenth = new OpSym;
+      auto cPrenth = std::make_shared<OpSym>();
       cPrenth->Sym = input[i];
       cPrenth->lineCount = lineCount;
       tokens.push(cPrenth);
       i++;
     } else if (input[i] == '=') {
       if (input[i + 1] == '=') {
-        auto equ = new lex::Symbol;
+        auto equ = std::make_shared<lex::Symbol>();
         equ->meta = "==";
         i++;
         equ->lineCount = lineCount;
         tokens << equ;
       } else {
-        auto equ = new OpSym;
+        auto equ = std::make_shared<OpSym>();
         equ->Sym = input[i];
         equ->lineCount = lineCount;
         tokens << equ;
       }
       i++;
     } else if (input[i] == '<') {
-      auto sym = new lex::Symbol;
+      auto sym = std::make_shared<lex::Symbol>();
       sym->meta = "<";
       if (input[i + 1] == '<') {
-        auto opSym = new lex::OpSym;
+        auto opSym = std::make_shared<lex::OpSym>();
         opSym->Sym = '<';
         opSym->lineCount = lineCount;
         tokens << opSym;
-        free(sym);
+
         i++;
       } else if (input[i + 1] == '=') {
         sym->meta = "<=";
@@ -292,13 +295,12 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
       }
       i++;
     } else if (input[i] == '>') {
-      auto *sym = new lex::Symbol;
+      auto sym = std::make_shared<lex::Symbol>();
       sym->meta = ">";
       if (input[i + 1] == '>') {
-        auto *opSym = new lex::OpSym;
+        auto opSym = std::make_shared<lex::OpSym>();
         opSym->Sym = '>';
         opSym->lineCount = lineCount;
-        free(sym);
         tokens << opSym;
         i++;
       } else if (input[i + 1] == '=') {
@@ -312,13 +314,12 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
       }
       i++;
     } else if (input[i] == '|') {
-      auto *sym = new lex::OpSym;
+      auto sym = std::make_shared<lex::OpSym>();
       sym->Sym = '|';
       if (input[i + 1] == '|') {
-        auto opSym = new lex::Symbol;
+        auto opSym = std::make_shared<lex::Symbol>();
         opSym->meta = "||";
         opSym->lineCount = lineCount;
-        free(sym);
         tokens << opSym;
         i++;
       } else {
@@ -328,67 +329,67 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
       i++;
     } else if (input[i] == '!') {
       if (input[i + 1] == '=') {
-        auto equ = new lex::Symbol;
+        auto equ = std::make_shared<lex::Symbol>();
         equ->meta = "!=";
         i++;
         equ->lineCount = lineCount;
         tokens << equ;
       } else {
-        auto equ = new OpSym;
+        auto equ = std::make_shared<OpSym>();
         equ->Sym = input[i];
         equ->lineCount = lineCount;
         tokens << equ;
       }
       i++;
     } else if (input[i] == ',') {
-      auto com = new OpSym;
+      auto com = std::make_shared<OpSym>();
       com->Sym = input[i];
       com->lineCount = lineCount;
       tokens.push(com);
       i++;
     } else if (input[i] == '+') {
-      auto add = new OpSym;
+      auto add = std::make_shared<OpSym>();
       add->Sym = input[i];
       add->lineCount = lineCount;
       tokens.push(add);
       i++;
     } else if (input[i] == '[') {
-      auto add = new OpSym;
+      auto add = std::make_shared<OpSym>();
       add->Sym = input[i];
       add->lineCount = lineCount;
       tokens.push(add);
       i++;
     } else if (input[i] == ']') {
-      auto add = new OpSym;
+      auto add = std::make_shared<OpSym>();
       add->Sym = input[i];
       add->lineCount = lineCount;
       tokens.push(add);
       i++;
     } else if (input[i] == '*') {
-      auto mul = new OpSym;
+      auto mul = std::make_shared<OpSym>();
       mul->Sym = input[i];
       mul->lineCount = lineCount;
       tokens << mul;
       i++;
     } else if (input[i] == '^') {
-      auto carrot = new OpSym;
+      auto carrot = std::make_shared<OpSym>();
       carrot->Sym = input[i];
       carrot->lineCount = lineCount;
       tokens << carrot;
       i++;
     } else if (input[i] == '%') {
-      auto mul = new OpSym;
+      auto mul = std::make_shared<OpSym>();
       mul->Sym = input[i];
       mul->lineCount = lineCount;
       tokens << mul;
       i++;
     } else if (input[i] == ':') {
-      auto col = new OpSym;
+      auto col = std::make_shared<OpSym>();
       col->Sym = input[i];
       col->lineCount = lineCount;
       i++;
       if (input[i] == ':') {
-        auto sym = new lex::Symbol;
+        auto sym = std::make_shared<lex::Symbol>();
         sym->meta = "::";
         sym->lineCount = lineCount;
         tokens << sym;
@@ -397,31 +398,31 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
         tokens << col;
       }
     } else if (input[i] == '@') {
-      auto at = new OpSym;
+      auto at = std::make_shared<OpSym>();
       at->Sym = input[i];
       at->lineCount = lineCount;
       tokens << at;
       i++;
     } else if (input[i] == '.') {
-      auto mul = new OpSym;
+      auto mul = std::make_shared<OpSym>();
       mul->Sym = input[i];
       mul->lineCount = lineCount;
       tokens << mul;
       i++;
     } else if (input[i] == '/') {
-      auto div = new OpSym;
+      auto div = std::make_shared<OpSym>();
       div->Sym = input[i];
       div->lineCount = lineCount;
       tokens << div;
       i++;
     } else if (input[i] == '&') {
-      auto andBit = new OpSym;
+      auto andBit = std::make_shared<OpSym>();
       andBit->Sym = input[i];
       andBit->lineCount = lineCount;
       tokens << andBit;
       i++;
     } else if (input[i] == '$') {
-      auto dollar = new OpSym;
+      auto dollar = std::make_shared<OpSym>();
       dollar->Sym = input[i];
       dollar->lineCount = lineCount;
       tokens << dollar;
@@ -432,7 +433,7 @@ LinkedList<lex::Token *> lex::Lexer::Scan(string input, int startLine) {
                            std::to_string(lineCount));
     }
   }
-  auto last_semi = new lex::OpSym;
+  auto last_semi = std::make_shared<lex::OpSym>();
   last_semi->Sym = ';';
   last_semi->lineCount = lineCount;
   tokens.push(last_semi);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -314,9 +314,11 @@ bool build(std::string path, std::string output, cfg::Mutability mutability,
   try {
     try {
       PreProcessor pp;
-      tokens = scanner.Scan(
+      auto tokenPtrs = scanner.Scan(
           pp.PreProcess(content, libPath,
                         std::filesystem::path(path).parent_path().string()));
+      tokenPtrs.invert();
+      tokens = lex::toRawList(tokenPtrs);
     } catch (int x) {
       int line = 1;
       for (int i = 0; i < x && i < content.size(); ++i)
@@ -325,7 +327,6 @@ bool build(std::string path, std::string output, cfg::Mutability mutability,
       error::report(path, line, "unparsable character", content);
       return false;
     }
-    tokens.invert();
     parse::Parser parser(mutability);
 
     auto Prog = parser.parseStmt(tokens);

--- a/test/test_DeepCopy.cpp
+++ b/test/test_DeepCopy.cpp
@@ -6,8 +6,9 @@
 TEST_CASE("deepCopy clones statements", "[deepcopy]") {
   lex::Lexer l;
   parse::Parser p;
-  auto tokens = l.Scan("return 1;");
-  tokens.invert();
+  auto tokenPtrs = l.Scan("return 1;");
+  tokenPtrs.invert();
+  auto tokens = lex::toRawList(tokenPtrs);
   ast::Statement *stmt = p.parseStmt(tokens, true);
   auto *ret = dynamic_cast<ast::Return *>(stmt);
   REQUIRE(ret != nullptr);

--- a/test/test_Ellipsis.cpp
+++ b/test/test_Ellipsis.cpp
@@ -4,8 +4,9 @@
 
 TEST_CASE("Parser handles ellipsis as a no-op statement", "[parser]") {
   lex::Lexer l;
-  auto tokens = l.Scan("...;");
-  tokens.invert();
+  auto tokenPtrs = l.Scan("...;");
+  tokenPtrs.invert();
+  auto tokens = lex::toRawList(tokenPtrs);
   parse::Parser p;
   ast::Statement *stmt = p.parseStmt(tokens);
   auto *seq = dynamic_cast<ast::Sequence *>(stmt);

--- a/test/test_Import.cpp
+++ b/test/test_Import.cpp
@@ -15,8 +15,9 @@ TEST_CASE("Parser handles mixed import of classes and functions", "[parser]") {
   lex::Lexer l;
   PreProcessor pp;
   auto code = pp.PreProcess("import Foo, {bar} from \"Mod\" under m;", "", "");
-  auto tokens = l.Scan(code);
-  tokens.invert();
+  auto tokenPtrs = l.Scan(code);
+  tokenPtrs.invert();
+  auto tokens = lex::toRawList(tokenPtrs);
   parse::Parser p;
   ast::Statement *stmt = p.parseStmt(tokens);
   auto *seq = dynamic_cast<ast::Sequence *>(stmt);
@@ -40,8 +41,9 @@ TEST_CASE("ImportsOnly ignores functions in mixed import", "[codegen]") {
   PreProcessor pp;
   auto code =
       pp.PreProcess("import Foo, {bar} from \"./Temp\" under m;", "", "");
-  auto tokens = l.Scan(code);
-  tokens.invert();
+  auto tokenPtrs = l.Scan(code);
+  tokenPtrs.invert();
+  auto tokens = lex::toRawList(tokenPtrs);
   parse::Parser p;
   ast::Statement *stmt = p.parseStmt(tokens);
   auto *seq = dynamic_cast<ast::Sequence *>(stmt);
@@ -73,8 +75,9 @@ TEST_CASE("Import applies nested namespaces", "[namespaces]") {
   lex::Lexer l;
   PreProcessor pp;
   auto code = pp.PreProcess("import {call} from \"./Outer\";", "", "");
-  auto tokens = l.Scan(code);
-  tokens.invert();
+  auto tokenPtrs = l.Scan(code);
+  tokenPtrs.invert();
+  auto tokens = lex::toRawList(tokenPtrs);
   parse::Parser p;
   ast::Statement *stmt = p.parseStmt(tokens);
   auto *seq = dynamic_cast<ast::Sequence *>(stmt);
@@ -92,8 +95,9 @@ TEST_CASE("Import applies nested namespaces", "[namespaces]") {
   outerFile.close();
   lex::Lexer l2;
   PreProcessor pp2;
-  auto t2 = l2.Scan(pp2.PreProcess(outerCode, "", ""));
-  t2.invert();
+  auto t2Ptrs = l2.Scan(pp2.PreProcess(outerCode, "", ""));
+  t2Ptrs.invert();
+  auto t2 = lex::toRawList(t2Ptrs);
   parse::Parser p2;
   ast::Statement *root = p2.parseStmt(t2);
   std::unordered_map<std::string, std::string> map;
@@ -161,8 +165,9 @@ TEST_CASE("Imports handle parent directory paths", "[imports]") {
   lex::Lexer l;
   PreProcessor pp;
   auto code = pp.PreProcess("import {call} from \"./sub/Outer\";", "", "");
-  auto tokens = l.Scan(code);
-  tokens.invert();
+  auto tokenPtrs = l.Scan(code);
+  tokenPtrs.invert();
+  auto tokens = lex::toRawList(tokenPtrs);
   parse::Parser p;
   ast::Statement *stmt = p.parseStmt(tokens);
   auto *seq = dynamic_cast<ast::Sequence *>(stmt);
@@ -198,8 +203,9 @@ TEST_CASE("ImportsOnly uses import working directory", "[imports]") {
   PreProcessor pp;
   auto code =
       pp.PreProcess("import {info} from \"./FlatLog\" under log;", "", "");
-  auto tokens = l.Scan(code);
-  tokens.invert();
+  auto tokenPtrs = l.Scan(code);
+  tokenPtrs.invert();
+  auto tokens = lex::toRawList(tokenPtrs);
   parse::Parser p;
   ast::Statement *stmt = p.parseStmt(tokens);
   auto *seq = dynamic_cast<ast::Sequence *>(stmt);

--- a/test/test_Scanner.cpp
+++ b/test/test_Scanner.cpp
@@ -5,8 +5,8 @@ TEST_CASE("Lexer scans identifiers and ints", "[scanner]") {
   lex::Lexer l;
   auto tokens = l.Scan("foo 123");
   REQUIRE(tokens.size() >= 3); // includes trailing semicolon token
-  auto *first = dynamic_cast<lex::LObj *>(tokens.get(2));
-  auto *second = dynamic_cast<lex::INT *>(tokens.get(1));
+  auto first = std::dynamic_pointer_cast<lex::LObj>(tokens.get(2));
+  auto second = std::dynamic_pointer_cast<lex::INT>(tokens.get(1));
   REQUIRE(first != nullptr);
   REQUIRE(first->meta == "foo");
   REQUIRE(second != nullptr);

--- a/test/test_When.cpp
+++ b/test/test_When.cpp
@@ -8,9 +8,10 @@
 
 TEST_CASE("Parser parses when clauses", "[parser][when]") {
   lex::Lexer l;
-  auto tokens =
+  auto tokenPtrs =
       l.Scan("when (T is dynamic and T has toString) fn foo() -> int {};", 1);
-  tokens.invert();
+  tokenPtrs.invert();
+  auto tokens = lex::toRawList(tokenPtrs);
   parse::Parser p;
   ast::Statement *stmt = p.parseStmt(tokens);
   auto *seq = dynamic_cast<ast::Sequence *>(stmt);
@@ -32,9 +33,10 @@ TEST_CASE("Parser parses when clauses", "[parser][when]") {
 
 TEST_CASE("Parser parses when clauses with or", "[parser][when]") {
   lex::Lexer l;
-  auto tokens =
+  auto tokenPtrs =
       l.Scan("when (T is dynamic or T has toString) fn foo() -> int {};", 1);
-  tokens.invert();
+  tokenPtrs.invert();
+  auto tokens = lex::toRawList(tokenPtrs);
   parse::Parser p;
   ast::Statement *stmt = p.parseStmt(tokens);
   auto *seq = dynamic_cast<ast::Sequence *>(stmt);


### PR DESCRIPTION
## Summary
- Return `LinkedList<std::shared_ptr<Token>>` from the lexer and provide a helper to convert to raw token lists
- Allocate tokens with `std::make_shared` and adjust callers to convert shared tokens before parsing
- Update unit tests for shared token interface

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./bin/a.test` *(fails: Error: can't open ../libraries/std/JSON_Property.s for reading: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae002510a08328a623341adc3f7388