### PR TITLE
Ensure when clauses validated during statement generation

### DIFF
--- a/src/CodeGenerator/Statements.cpp
+++ b/src/CodeGenerator/Statements.cpp
@@ -17,6 +17,10 @@ namespace gen {
 links::LinkedList<gen::Symbol>
 gen::CodeGenerator::GenTable(ast::Statement *STMT,
                              links::LinkedList<gen::Symbol> &table) {
+  if (STMT->when && !this->whenSatisfied(*STMT->when)) {
+    return table;
+  }
+
   if (dynamic_cast<ast::Sequence *>(STMT) != nullptr) {
     ast::Sequence *sequence = dynamic_cast<ast::Sequence *>(STMT);
     this->GenTable(sequence->Statement1, table);
@@ -76,6 +80,10 @@ asmc::File gen::CodeGenerator::GenArgs(ast::Statement *STMT,
                                        asmc::File &OutputFile,
                                        const ast::Function &func, int &index) {
   asmc::File output;
+  if (STMT->when && !this->whenSatisfied(*STMT->when)) {
+    return output;
+  }
+
   if (dynamic_cast<ast::Sequence *>(STMT) != nullptr) {
     ast::Sequence *sequence = dynamic_cast<ast::Sequence *>(STMT);
     output << this->GenArgs(sequence->Statement1, OutputFile, func, index);
@@ -251,6 +259,10 @@ asmc::File gen::CodeGenerator::GenSTMT(ast::Statement *STMT) {
 
 asmc::File gen::CodeGenerator::ImportsOnly(ast::Statement *STMT) {
   asmc::File OutputFile = asmc::File();
+  if (STMT->when && !this->whenSatisfied(*STMT->when)) {
+    return OutputFile;
+  }
+
   if (STMT->locked) {
     auto *inst = new asmc::nop();
     inst->logicalLine = STMT->logicalLine;

--- a/test/test_When.cpp
+++ b/test/test_When.cpp
@@ -72,3 +72,76 @@ TEST_CASE("when resolution checks primitive", "[when][resolution]") {
   w.predicates.push_back(pred2);
   CHECK(gen.whenSatisfied(w));
 }
+
+TEST_CASE("GenTable skips statements with failing when", "[when][codegen]") {
+  parse::Parser p;
+  gen::CodeGenerator gen("mod", p, "",
+                         std::filesystem::current_path().string());
+
+  links::LinkedList<gen::Symbol> table;
+  auto *decl = new ast::Declare();
+  decl->ident = "x";
+  decl->type = ast::Type("int", asmc::DWord);
+
+  ast::When w;
+  ast::WhenPredicat pred;
+  pred.op = ast::WhenOperator::IS;
+  pred.typeName = "Foo";
+  pred.ident = "primitive";
+  pred.negated = false;
+  w.predicates.push_back(pred);
+  decl->when = w;
+
+  gen.GenTable(decl, table);
+  CHECK(table.head == nullptr);
+}
+
+TEST_CASE("GenArgs skips statements with failing when", "[when][codegen]") {
+  parse::Parser p;
+  gen::CodeGenerator gen("mod", p, "",
+                         std::filesystem::current_path().string());
+
+  ast::Function func;
+  func.argTypes.push_back(ast::Type("int", asmc::DWord));
+  asmc::File outFile;
+  int index = 0;
+
+  auto *decl = new ast::Declare();
+  decl->ident = "x";
+  decl->type = ast::Type("int", asmc::DWord);
+
+  ast::When w;
+  ast::WhenPredicat pred;
+  pred.op = ast::WhenOperator::IS;
+  pred.typeName = "Foo";
+  pred.ident = "primitive";
+  pred.negated = false;
+  w.predicates.push_back(pred);
+  decl->when = w;
+
+  auto out = gen.GenArgs(decl, outFile, func, index);
+  CHECK(out.text.head == nullptr);
+  CHECK(index == 0);
+}
+
+TEST_CASE("ImportsOnly skips statements with failing when", "[when][codegen]") {
+  parse::Parser p;
+  gen::CodeGenerator gen("mod", p, "",
+                         std::filesystem::current_path().string());
+
+  auto *decl = new ast::Declare();
+  decl->ident = "x";
+  decl->type = ast::Type("int", asmc::DWord);
+
+  ast::When w;
+  ast::WhenPredicat pred;
+  pred.op = ast::WhenOperator::IS;
+  pred.typeName = "Foo";
+  pred.ident = "primitive";
+  pred.negated = false;
+  w.predicates.push_back(pred);
+  decl->when = w;
+
+  auto out = gen.ImportsOnly(decl);
+  CHECK(out.text.head == nullptr);
+}


### PR DESCRIPTION
## Summary
- Guard GenTable, GenArgs, and ImportsOnly so statements are skipped when `when` predicates are unsatisfied
- Add unit tests covering `when` handling in code generation helpers

## Testing
- `./bin/a.test` *(fails: can't open ../libraries/std/... .s files)*

------
https://chatgpt.com/codex/tasks/task_e_68ae17166cf883289b47388186c9de68